### PR TITLE
✨ feat: 添加权限模型并按权限过滤菜单与命令

### DIFF
--- a/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,14 +5,16 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+node .gitnexus/run.cjs analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -28,7 +30,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+node .gitnexus/run.cjs status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +38,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+node .gitnexus/run.cjs clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +51,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+node .gitnexus/run.cjs wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +68,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+node .gitnexus/run.cjs list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -15,24 +15,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Workflow
 
-```
-1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
-2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+```text
+1. query({query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+4. cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] gitnexus_query for error text or related code
+- [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] gitnexus_context to see callers and callees
+- [ ] context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,7 +40,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Error message        | `query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
@@ -48,24 +48,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Tools
 
-**gitnexus_query** — find code related to error:
+**query** — find code related to error:
 
-```
-gitnexus_query({query: "payment validation error"})
+```text
+query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**gitnexus_context** — full context for a suspect:
+**context** — full context for a suspect:
 
-```
-gitnexus_context({name: "validatePayment"})
+```text
+context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**gitnexus_cypher** — custom call chain traces:
+**cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
@@ -74,12 +74,12 @@ RETURN [n IN nodes(path) | n.name] AS chain
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
-```
-1. gitnexus_query({query: "payment error handling"})
+```text
+1. query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. gitnexus_context({name: "validatePayment"})
+2. context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -15,23 +15,23 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Workflow
 
-```
+```text
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
-4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+3. query({query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] gitnexus_query for the concept you want to understand
+- [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**gitnexus_query** — find execution flows related to a concept:
+**query** — find execution flows related to a concept:
 
-```
-gitnexus_query({query: "payment processing"})
+```text
+query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**gitnexus_context** — 360-degree view of a symbol:
+**context** — 360-degree view of a symbol:
 
-```
-gitnexus_context({name: "validateUser"})
+```text
+context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -66,12 +66,12 @@ gitnexus_context({name: "validateUser"})
 
 ## Example: "How does payment processing work?"
 
-```
+```text
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. gitnexus_query({query: "payment processing"})
+2. query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. gitnexus_context({name: "processPayment"})
+3. context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```text
-1. READ gitnexus://repos                          → Discover indexed repos
+1. list_repos({})                                → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({query: "<what you want to understand>"})  → Find related execution flows
 4. context({name: "<symbol>"})            → Deep dive on specific symbol

--- a/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
 
 ## Skills
 
@@ -38,7 +38,38 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
 
 ## Resources Reference
 

--- a/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+```text
+1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+3. detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
-- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+```text
+- [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**gitnexus_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
-```
-gitnexus_impact({
+```text
+impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ gitnexus_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**gitnexus_detect_changes** — git-diff based impact analysis:
+**detect_changes** — git-diff based impact analysis:
 
-```
-gitnexus_detect_changes({scope: "staged"})
+```text
+detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -85,8 +85,8 @@ gitnexus_detect_changes({scope: "staged"})
 
 ## Example: "What breaks if I change validateUser?"
 
-```
-1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.agents/skills/gitnexus/gitnexus-pr-review/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-pr-review/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Workflow
 
-```
+```text
 1. gh pr diff <number>                                    → Get the raw diff
 2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
 3. For each changed symbol:
@@ -30,7 +30,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Checklist
 
-```
+```text
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
 - [ ] gitnexus_detect_changes to map changes to affected execution flows
 - [ ] gitnexus_impact on each non-trivial changed symbol
@@ -65,7 +65,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 **gitnexus_detect_changes** — map PR diff to affected execution flows:
 
-```
+```text
 gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 → Changed: 8 symbols in 4 files
@@ -75,7 +75,7 @@ gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 **gitnexus_impact** — blast radius per changed symbol:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 → d=1 (WILL BREAK):
@@ -88,7 +88,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 **gitnexus_impact with tests** — check test coverage:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests: true})
 
 → Tests that cover this symbol:
@@ -98,7 +98,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests:
 
 **gitnexus_context** — understand a changed symbol's role:
 
-```
+```text
 gitnexus_context({name: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
@@ -108,7 +108,7 @@ gitnexus_context({name: "validatePayment"})
 
 ## Example: "Review PR #42"
 
-```
+```text
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 

--- a/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -15,79 +15,79 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. gitnexus_query({query: "X"})                            → Find execution flows involving X
-3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+```text
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
-```
-- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+```text
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
-- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
-```
-- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
-- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+```text
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
-```
-- [ ] gitnexus_context({name: target}) — understand all callees
+```text
+- [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**gitnexus_rename** — automated multi-file rename:
+**rename** — automated multi-file rename:
 
-```
-gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**gitnexus_impact** — map all dependents first:
+**impact** — map all dependents first:
 
-```
-gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**gitnexus_detect_changes** — verify your changes after refactoring:
+**detect_changes** — verify your changes after refactoring:
 
-```
-gitnexus_detect_changes({scope: "all"})
+```text
+detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**gitnexus_cypher** — custom reference queries:
+**cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Many callers (>5)   | Use rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | gitnexus_query to find them               |
+| String/dynamic refs | query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
-```
-1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. gitnexus_detect_changes({scope: "all"})
+4. detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Workflow
 
-```
+```text
 1. query({query: "<error or symptom>"})            → Find related execution flows
 2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
@@ -26,7 +26,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Checklist
 
-```
+```text
 - [ ] Understand the symptom (error message, unexpected behavior)
 - [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
@@ -50,7 +50,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 **query** — find code related to error:
 
-```
+```text
 query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
@@ -58,7 +58,7 @@ query({query: "payment validation error"})
 
 **context** — full context for a suspect:
 
-```
+```text
 context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
@@ -74,7 +74,7 @@ RETURN [n IN nodes(path) | n.name] AS chain
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
-```
+```text
 1. query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```text
-1. READ gitnexus://repos                          → Discover indexed repos
+1. list_repos({})                                → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({query: "<what you want to understand>"})  → Find related execution flows
 4. context({name: "<symbol>"})            → Deep dive on specific symbol

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Workflow
 
-```
+```text
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({query: "<what you want to understand>"})  → Find related execution flows
@@ -27,7 +27,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Checklist
 
-```
+```text
 - [ ] READ gitnexus://repo/{name}/context
 - [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
@@ -49,7 +49,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 **query** — find execution flows related to a concept:
 
-```
+```text
 query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
@@ -57,7 +57,7 @@ query({query: "payment processing"})
 
 **context** — 360-degree view of a symbol:
 
-```
+```text
 context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
@@ -66,7 +66,7 @@ context({name: "validateUser"})
 
 ## Example: "How does payment processing work?"
 
-```
+```text
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
 2. query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Workflow
 
-```
+```text
 1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
 3. detect_changes()                               → Map current git changes to affected flows
@@ -27,7 +27,7 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Checklist
 
-```
+```text
 - [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
@@ -57,7 +57,7 @@ description: "Use when the user wants to know what will break if they change som
 
 **impact** — the primary tool for symbol blast radius:
 
-```
+```text
 impact({
   target: "validateUser",
   direction: "upstream",
@@ -75,7 +75,7 @@ impact({
 
 **detect_changes** — git-diff based impact analysis:
 
-```
+```text
 detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
@@ -85,7 +85,7 @@ detect_changes({scope: "staged"})
 
 ## Example: "What breaks if I change validateUser?"
 
-```
+```text
 1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)

--- a/.claude/skills/gitnexus/gitnexus-pr-review/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-pr-review/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Workflow
 
-```
+```text
 1. gh pr diff <number>                                    → Get the raw diff
 2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
 3. For each changed symbol:
@@ -30,7 +30,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Checklist
 
-```
+```text
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
 - [ ] gitnexus_detect_changes to map changes to affected execution flows
 - [ ] gitnexus_impact on each non-trivial changed symbol
@@ -65,7 +65,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 **gitnexus_detect_changes** — map PR diff to affected execution flows:
 
-```
+```text
 gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 → Changed: 8 symbols in 4 files
@@ -75,7 +75,7 @@ gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 **gitnexus_impact** — blast radius per changed symbol:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 → d=1 (WILL BREAK):
@@ -88,7 +88,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 **gitnexus_impact with tests** — check test coverage:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests: true})
 
 → Tests that cover this symbol:
@@ -98,7 +98,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests:
 
 **gitnexus_context** — understand a changed symbol's role:
 
-```
+```text
 gitnexus_context({name: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
@@ -108,7 +108,7 @@ gitnexus_context({name: "validatePayment"})
 
 ## Example: "Review PR #42"
 
-```
+```text
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ## Workflow
 
-```
+```text
 1. impact({target: "X", direction: "upstream"})  → Map all dependents
 2. query({query: "X"})                            → Find execution flows involving X
 3. context({name: "X"})                           → See all incoming/outgoing refs
@@ -28,7 +28,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Rename Symbol
 
-```
+```text
 - [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
 - [ ] If satisfied: rename({..., dry_run: false}) — apply edits
@@ -38,7 +38,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Extract Module
 
-```
+```text
 - [ ] context({name: target}) — see all incoming/outgoing refs
 - [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
@@ -49,7 +49,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Split Function/Service
 
-```
+```text
 - [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
 - [ ] impact({target, direction: "upstream"}) — map callers to update
@@ -63,7 +63,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 **rename** — automated multi-file rename:
 
-```
+```text
 rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
@@ -72,7 +72,7 @@ rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true
 
 **impact** — map all dependents first:
 
-```
+```text
 impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
@@ -80,7 +80,7 @@ impact({target: "validateUser", direction: "upstream"})
 
 **detect_changes** — verify your changes after refactoring:
 
-```
+```text
 detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
@@ -105,7 +105,7 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
-```
+```text
 1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...

--- a/.trae/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,14 +5,16 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+node .gitnexus/run.cjs analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -28,7 +30,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+node .gitnexus/run.cjs status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +38,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+node .gitnexus/run.cjs clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +51,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+node .gitnexus/run.cjs wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +68,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+node .gitnexus/run.cjs list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.trae/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -15,24 +15,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Workflow
 
-```
-1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
-2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+```text
+1. query({query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+4. cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] gitnexus_query for error text or related code
+- [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] gitnexus_context to see callers and callees
+- [ ] context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,7 +40,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Error message        | `query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
@@ -48,24 +48,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Tools
 
-**gitnexus_query** — find code related to error:
+**query** — find code related to error:
 
-```
-gitnexus_query({query: "payment validation error"})
+```text
+query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**gitnexus_context** — full context for a suspect:
+**context** — full context for a suspect:
 
-```
-gitnexus_context({name: "validatePayment"})
+```text
+context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**gitnexus_cypher** — custom call chain traces:
+**cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
@@ -74,12 +74,12 @@ RETURN [n IN nodes(path) | n.name] AS chain
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
-```
-1. gitnexus_query({query: "payment error handling"})
+```text
+1. query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. gitnexus_context({name: "validatePayment"})
+2. context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.trae/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -15,23 +15,23 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Workflow
 
-```
+```text
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
-4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+3. query({query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] gitnexus_query for the concept you want to understand
+- [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**gitnexus_query** — find execution flows related to a concept:
+**query** — find execution flows related to a concept:
 
-```
-gitnexus_query({query: "payment processing"})
+```text
+query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**gitnexus_context** — 360-degree view of a symbol:
+**context** — 360-degree view of a symbol:
 
-```
-gitnexus_context({name: "validateUser"})
+```text
+context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -66,12 +66,12 @@ gitnexus_context({name: "validateUser"})
 
 ## Example: "How does payment processing work?"
 
-```
+```text
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. gitnexus_query({query: "payment processing"})
+2. query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. gitnexus_context({name: "processPayment"})
+3. context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.trae/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```text
-1. READ gitnexus://repos                          → Discover indexed repos
+1. list_repos({})                                → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({query: "<what you want to understand>"})  → Find related execution flows
 4. context({name: "<symbol>"})            → Deep dive on specific symbol

--- a/.trae/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
 
 ## Skills
 
@@ -38,7 +38,38 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
 
 ## Resources Reference
 

--- a/.trae/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+```text
+1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+3. detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
-- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+```text
+- [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**gitnexus_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
-```
-gitnexus_impact({
+```text
+impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ gitnexus_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**gitnexus_detect_changes** — git-diff based impact analysis:
+**detect_changes** — git-diff based impact analysis:
 
-```
-gitnexus_detect_changes({scope: "staged"})
+```text
+detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -85,8 +85,8 @@ gitnexus_detect_changes({scope: "staged"})
 
 ## Example: "What breaks if I change validateUser?"
 
-```
-1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.trae/skills/gitnexus/gitnexus-pr-review/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-pr-review/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Workflow
 
-```
+```text
 1. gh pr diff <number>                                    → Get the raw diff
 2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
 3. For each changed symbol:
@@ -30,7 +30,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Checklist
 
-```
+```text
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
 - [ ] gitnexus_detect_changes to map changes to affected execution flows
 - [ ] gitnexus_impact on each non-trivial changed symbol
@@ -65,7 +65,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 **gitnexus_detect_changes** — map PR diff to affected execution flows:
 
-```
+```text
 gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 → Changed: 8 symbols in 4 files
@@ -75,7 +75,7 @@ gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 **gitnexus_impact** — blast radius per changed symbol:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 → d=1 (WILL BREAK):
@@ -88,7 +88,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 **gitnexus_impact with tests** — check test coverage:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests: true})
 
 → Tests that cover this symbol:
@@ -98,7 +98,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests:
 
 **gitnexus_context** — understand a changed symbol's role:
 
-```
+```text
 gitnexus_context({name: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
@@ -108,7 +108,7 @@ gitnexus_context({name: "validatePayment"})
 
 ## Example: "Review PR #42"
 
-```
+```text
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 

--- a/.trae/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.trae/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -15,79 +15,79 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. gitnexus_query({query: "X"})                            → Find execution flows involving X
-3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+```text
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
-```
-- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+```text
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
-- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
-```
-- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
-- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+```text
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
-```
-- [ ] gitnexus_context({name: target}) — understand all callees
+```text
+- [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**gitnexus_rename** — automated multi-file rename:
+**rename** — automated multi-file rename:
 
-```
-gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**gitnexus_impact** — map all dependents first:
+**impact** — map all dependents first:
 
-```
-gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**gitnexus_detect_changes** — verify your changes after refactoring:
+**detect_changes** — verify your changes after refactoring:
 
-```
-gitnexus_detect_changes({scope: "all"})
+```text
+detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**gitnexus_cypher** — custom reference queries:
+**cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Many callers (>5)   | Use rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | gitnexus_query to find them               |
+| String/dynamic refs | query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
-```
-1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. gitnexus_detect_changes({scope: "all"})
+4. detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **lingchu-bot** (3841 symbols, 6760 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **lingchu-bot** (4116 symbols, 7241 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **lingchu-bot** (3841 symbols, 6760 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **lingchu-bot** (4116 symbols, 7241 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,14 +5,16 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+node .gitnexus/run.cjs analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -28,7 +30,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+node .gitnexus/run.cjs status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +38,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+node .gitnexus/run.cjs clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +51,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+node .gitnexus/run.cjs wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +68,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+node .gitnexus/run.cjs list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -15,24 +15,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Workflow
 
-```
-1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
-2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+```text
+1. query({query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+4. cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] gitnexus_query for error text or related code
+- [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] gitnexus_context to see callers and callees
+- [ ] context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,7 +40,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Error message        | `query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
@@ -48,24 +48,24 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Tools
 
-**gitnexus_query** — find code related to error:
+**query** — find code related to error:
 
-```
-gitnexus_query({query: "payment validation error"})
+```text
+query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**gitnexus_context** — full context for a suspect:
+**context** — full context for a suspect:
 
-```
-gitnexus_context({name: "validatePayment"})
+```text
+context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**gitnexus_cypher** — custom call chain traces:
+**cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
@@ -74,12 +74,12 @@ RETURN [n IN nodes(path) | n.name] AS chain
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
-```
-1. gitnexus_query({query: "payment error handling"})
+```text
+1. query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. gitnexus_context({name: "validatePayment"})
+2. context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -15,23 +15,23 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Workflow
 
-```
+```text
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
-4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+3. query({query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
+```text
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] gitnexus_query for the concept you want to understand
+- [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**gitnexus_query** — find execution flows related to a concept:
+**query** — find execution flows related to a concept:
 
-```
-gitnexus_query({query: "payment processing"})
+```text
+query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**gitnexus_context** — 360-degree view of a symbol:
+**context** — 360-degree view of a symbol:
 
-```
-gitnexus_context({name: "validateUser"})
+```text
+context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -66,12 +66,12 @@ gitnexus_context({name: "validateUser"})
 
 ## Example: "How does payment processing work?"
 
-```
+```text
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. gitnexus_query({query: "payment processing"})
+2. query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. gitnexus_context({name: "processPayment"})
+3. context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```text
-1. READ gitnexus://repos                          → Discover indexed repos
+1. list_repos({})                                → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({query: "<what you want to understand>"})  → Find related execution flows
 4. context({name: "<symbol>"})            → Deep dive on specific symbol

--- a/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
 
 ## Skills
 
@@ -38,7 +38,38 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
 
 ## Resources Reference
 

--- a/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+```text
+1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+3. detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
-```
-- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+```text
+- [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**gitnexus_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
-```
-gitnexus_impact({
+```text
+impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ gitnexus_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**gitnexus_detect_changes** — git-diff based impact analysis:
+**detect_changes** — git-diff based impact analysis:
 
-```
-gitnexus_detect_changes({scope: "staged"})
+```text
+detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -85,8 +85,8 @@ gitnexus_detect_changes({scope: "staged"})
 
 ## Example: "What breaks if I change validateUser?"
 
-```
-1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/skills/gitnexus/gitnexus-pr-review/SKILL.md
+++ b/skills/gitnexus/gitnexus-pr-review/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Workflow
 
-```
+```text
 1. gh pr diff <number>                                    → Get the raw diff
 2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
 3. For each changed symbol:
@@ -30,7 +30,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Checklist
 
-```
+```text
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
 - [ ] gitnexus_detect_changes to map changes to affected execution flows
 - [ ] gitnexus_impact on each non-trivial changed symbol
@@ -65,7 +65,7 @@ description: "Use when the user wants to review a pull request, understand what 
 
 **gitnexus_detect_changes** — map PR diff to affected execution flows:
 
-```
+```text
 gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 → Changed: 8 symbols in 4 files
@@ -75,7 +75,7 @@ gitnexus_detect_changes({scope: "compare", base_ref: "main"})
 
 **gitnexus_impact** — blast radius per changed symbol:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 → d=1 (WILL BREAK):
@@ -88,7 +88,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream"})
 
 **gitnexus_impact with tests** — check test coverage:
 
-```
+```text
 gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests: true})
 
 → Tests that cover this symbol:
@@ -98,7 +98,7 @@ gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests:
 
 **gitnexus_context** — understand a changed symbol's role:
 
-```
+```text
 gitnexus_context({name: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
@@ -108,7 +108,7 @@ gitnexus_context({name: "validatePayment"})
 
 ## Example: "Review PR #42"
 
-```
+```text
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 

--- a/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -15,79 +15,79 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ## Workflow
 
-```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. gitnexus_query({query: "X"})                            → Find execution flows involving X
-3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+```text
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
-```
-- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+```text
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
-- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
-```
-- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
-- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+```text
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
-```
-- [ ] gitnexus_context({name: target}) — understand all callees
+```text
+- [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**gitnexus_rename** — automated multi-file rename:
+**rename** — automated multi-file rename:
 
-```
-gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**gitnexus_impact** — map all dependents first:
+**impact** — map all dependents first:
 
-```
-gitnexus_impact({target: "validateUser", direction: "upstream"})
+```text
+impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**gitnexus_detect_changes** — verify your changes after refactoring:
+**detect_changes** — verify your changes after refactoring:
 
-```
-gitnexus_detect_changes({scope: "all"})
+```text
+detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**gitnexus_cypher** — custom reference queries:
+**cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Many callers (>5)   | Use rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | gitnexus_query to find them               |
+| String/dynamic refs | query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
-```
-1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+```text
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. gitnexus_detect_changes({scope: "all"})
+4. detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
@@ -8,7 +8,15 @@ from nonebot import require
 
 require("nonebot_plugin_orm")
 from nonebot_plugin_orm import Model
-from sqlalchemy import Boolean, DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -183,7 +191,10 @@ class PermissionGroupMember(Model):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    group_id: Mapped[int] = mapped_column(Integer, index=True)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("lingchu_permission_groups.id", ondelete="CASCADE"),
+        index=True,
+    )
     platform_id: Mapped[str] = mapped_column(String(64), index=True)
     user_id: Mapped[str] = mapped_column(String(128), index=True)
     resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
@@ -220,8 +231,14 @@ class PermissionGrant(Model):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    group_id: Mapped[int] = mapped_column(Integer, index=True)
-    node_id: Mapped[int] = mapped_column(Integer, index=True)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("lingchu_permission_groups.id", ondelete="CASCADE"),
+        index=True,
+    )
+    node_id: Mapped[int] = mapped_column(
+        ForeignKey("lingchu_permission_nodes.id", ondelete="CASCADE"),
+        index=True,
+    )
     resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
     resource_id: Mapped[str | None] = mapped_column(String(128), index=True)
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)

--- a/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
@@ -278,7 +278,10 @@ class NativeRoleMapping(Model):
     adapter_id: Mapped[str | None] = mapped_column(String(64), index=True)
     resource_type: Mapped[str] = mapped_column(String(64), index=True)
     native_role: Mapped[str] = mapped_column(String(64), index=True)
-    group_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    group_id: Mapped[int | None] = mapped_column(
+        ForeignKey("lingchu_permission_groups.id", ondelete="CASCADE"),
+        index=True,
+    )
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/database/models.py
@@ -8,7 +8,7 @@ from nonebot import require
 
 require("nonebot_plugin_orm")
 from nonebot_plugin_orm import Model
-from sqlalchemy import DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -105,5 +105,235 @@ class BlocklistEntry(Model):
         DateTime(timezone=True),
         default=utc_now,
         onupdate=utc_now,
+        index=True,
+    )
+
+
+class PermissionNode(Model):
+    """Materialized permission tree node."""
+
+    __tablename__ = "lingchu_permission_nodes"
+    __table_args__ = (UniqueConstraint("path", name="uq_lingchu_permission_node_path"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    path: Mapped[str] = mapped_column(String(512), index=True)
+    parent_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    kind: Mapped[str] = mapped_column(String(32), index=True)
+    platform_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    adapter_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    implementation_name: Mapped[str | None] = mapped_column(String(128), index=True)
+    command_key: Mapped[str | None] = mapped_column(String(128), index=True)
+    resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
+    resource_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    title: Mapped[str | None] = mapped_column(String(256))
+    is_builtin: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class PermissionGroup(Model):
+    """Internal virtual identity group."""
+
+    __tablename__ = "lingchu_permission_groups"
+    __table_args__ = (UniqueConstraint("key", name="uq_lingchu_permission_group_key"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(128), index=True)
+    name: Mapped[str] = mapped_column(String(256))
+    parent_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    priority: Mapped[int] = mapped_column(Integer, default=0, index=True)
+    is_builtin: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class PermissionGroupMember(Model):
+    """Binding from a platform user to an internal permission group."""
+
+    __tablename__ = "lingchu_permission_group_members"
+    __table_args__ = (
+        UniqueConstraint(
+            "group_id",
+            "platform_id",
+            "user_id",
+            "resource_type",
+            "resource_id",
+            name="uq_lingchu_permission_group_member_identity",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(Integer, index=True)
+    platform_id: Mapped[str] = mapped_column(String(64), index=True)
+    user_id: Mapped[str] = mapped_column(String(128), index=True)
+    resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
+    resource_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class PermissionGrant(Model):
+    """Grant a group access to a permission node subtree."""
+
+    __tablename__ = "lingchu_permission_grants"
+    __table_args__ = (
+        UniqueConstraint(
+            "group_id",
+            "node_id",
+            "resource_type",
+            "resource_id",
+            name="uq_lingchu_permission_grant_identity",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(Integer, index=True)
+    node_id: Mapped[int] = mapped_column(Integer, index=True)
+    resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
+    resource_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class NativeRoleMapping(Model):
+    """Map native platform roles to internal permission groups."""
+
+    __tablename__ = "lingchu_native_role_mappings"
+    __table_args__ = (
+        UniqueConstraint(
+            "platform_id",
+            "adapter_id",
+            "resource_type",
+            "native_role",
+            name="uq_lingchu_native_role_mapping_identity",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str] = mapped_column(String(64), index=True)
+    adapter_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    resource_type: Mapped[str] = mapped_column(String(64), index=True)
+    native_role: Mapped[str] = mapped_column(String(64), index=True)
+    group_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class CapabilityContract(Model):
+    """Runtime capability contract for a platform/adapter/implementation command."""
+
+    __tablename__ = "lingchu_capability_contracts"
+    __table_args__ = (
+        UniqueConstraint(
+            "platform_id",
+            "adapter_id",
+            "implementation_name",
+            "command_key",
+            name="uq_lingchu_capability_contract_identity",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str] = mapped_column(String(64), index=True)
+    adapter_id: Mapped[str] = mapped_column(String(64), index=True)
+    implementation_name: Mapped[str | None] = mapped_column(String(128), index=True)
+    command_key: Mapped[str] = mapped_column(String(128), index=True)
+    capability: Mapped[str] = mapped_column(String(128), index=True)
+    minimum_version: Mapped[str | None] = mapped_column(String(64))
+    protocol_version: Mapped[str | None] = mapped_column(String(64))
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        index=True,
+    )
+
+
+class PermissionAuditLog(Model):
+    """Internal audit log for permission and impersonated platform operations."""
+
+    __tablename__ = "lingchu_permission_audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    adapter_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    implementation_name: Mapped[str | None] = mapped_column(String(128), index=True)
+    bot_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    user_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    resource_type: Mapped[str | None] = mapped_column(String(64), index=True)
+    resource_id: Mapped[str | None] = mapped_column(String(128), index=True)
+    command_key: Mapped[str | None] = mapped_column(String(128), index=True)
+    action: Mapped[str] = mapped_column(String(64), index=True)
+    result: Mapped[str] = mapped_column(String(64), index=True)
+    group_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    grant_node_id: Mapped[int | None] = mapped_column(Integer, index=True)
+    reason: Mapped[str | None] = mapped_column(Text)
+    exception_summary: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
         index=True,
     )

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/menu.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/menu.py
@@ -377,19 +377,25 @@ MENU_FEATURES: Final[tuple[MenuFeature, ...]] = (
 def render_menu(
     locale: str | None = None,
     context: MenuRuntimeContext | None = None,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> str:
-    return render_menu_index(context or default_menu_context(), locale)
+    return render_menu_index(
+        context or default_menu_context(),
+        locale,
+        allowed_command_keys,
+    )
 
 
 def render_menu_index(
     context: MenuRuntimeContext,
     locale: str | None = None,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> str:
     selected_locale = normalize_locale(locale or get_configured_locale())
     lines = [gettext("灵初功能菜单", selected_locale)]
 
     for page in MENU_PAGE_COMMANDS:
-        if not _page_has_visible_content(page, context):
+        if not _page_has_visible_content(page, context, allowed_command_keys):
             continue
         title = _localized(page.title, selected_locale)
         command = _localized(page.command, selected_locale)
@@ -407,20 +413,28 @@ def _render_menu_index_entry(title: str, command: str) -> str:
 def render_menu_for_context(
     context: MenuRuntimeContext,
     locale: str | None = None,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> str:
-    return render_menu_index(context, locale)
+    return render_menu_index(context, locale, allowed_command_keys)
 
 
 def render_menu_page(
     page_id: str,
     context: MenuRuntimeContext,
     locale: str | None = None,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> str:
     selected_locale = normalize_locale(locale or get_configured_locale())
     page = _MENU_PAGE_BY_ID[page_id]
     lines = [_localized(page.title, selected_locale)]
     lines.extend(
-        _render_page_body(page, context, selected_locale, include_self_title=False)
+        _render_page_body(
+            page,
+            context,
+            selected_locale,
+            allowed_command_keys=allowed_command_keys,
+            include_self_title=False,
+        )
     )
 
     if len(lines) == 1:
@@ -463,12 +477,13 @@ def _render_section(
     section: MenuSection,
     context: MenuRuntimeContext,
     locale: str,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> list[str]:
     title = _localized(section.title, locale)
     lines = [f"【{title}】"]
 
     for feature in _features_for_section(section.id):
-        rendered = _render_feature(feature, context, locale)
+        rendered = _render_feature(feature, context, locale, allowed_command_keys)
         if rendered:
             lines.append(rendered)
 
@@ -482,10 +497,16 @@ def _render_page_body(
     context: MenuRuntimeContext,
     locale: str,
     *,
+    allowed_command_keys: frozenset[str] | None,
     include_self_title: bool,
 ) -> list[str]:
     lines: list[str] = []
-    section = _render_section(MenuSection(page.id, page.title), context, locale)
+    section = _render_section(
+        MenuSection(page.id, page.title),
+        context,
+        locale,
+        allowed_command_keys,
+    )
     if section:
         if include_self_title:
             lines.extend(("", *section))
@@ -497,6 +518,7 @@ def _render_page_body(
             child,
             context,
             locale,
+            allowed_command_keys=allowed_command_keys,
             include_self_title=True,
         )
         if child_lines:
@@ -505,9 +527,14 @@ def _render_page_body(
     return lines
 
 
-def _page_has_visible_content(page: MenuPage, context: MenuRuntimeContext) -> bool:
+def _page_has_visible_content(
+    page: MenuPage,
+    context: MenuRuntimeContext,
+    allowed_command_keys: frozenset[str] | None = None,
+) -> bool:
     return any(
-        _matched_availability(feature, context) for feature in _page_features(page)
+        _matched_availability(feature, context, allowed_command_keys)
+        for feature in _page_features(page)
     )
 
 
@@ -525,8 +552,9 @@ def _render_feature(
     feature: MenuFeature,
     context: MenuRuntimeContext,
     locale: str,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> str:
-    availability = _matched_availability(feature, context)
+    availability = _matched_availability(feature, context, allowed_command_keys)
     if availability is None:
         return ""
 
@@ -556,9 +584,15 @@ def _localized(value: Any, locale: str) -> str:
 def _matched_availability(
     feature: MenuFeature,
     context: MenuRuntimeContext,
+    allowed_command_keys: frozenset[str] | None = None,
 ) -> MenuAvailability | None:
     if feature.command_key not in COMMAND_TRIGGERS:
         logger.debug(f"Lingchu 菜单跳过未知命令: {feature.command_key!r}")
+        return None
+    if (
+        allowed_command_keys is not None
+        and feature.command_key not in allowed_command_keys
+    ):
         return None
     if feature.platform_capability not in context.platform_capabilities:
         return None

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/announcement.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/announcement.py
@@ -12,6 +12,7 @@ from nonebot_plugin_alconna.uniseg import Image as UniImage
 
 from ....core.config import plugin_config
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _SEND_ANNOUNCEMENT = COMMAND_TRIGGERS["send_announcement"]
@@ -62,6 +63,7 @@ send_group_announcement_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(send_group_announcement_cmd, "send_announcement")
 
 _LAZY_EXPORTS = {
     "milkybot_send_group_announcement": "..milky.v1_2.default.group.announcement",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/block.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/block.py
@@ -8,6 +8,7 @@ from nonebot_plugin_alconna import AlconnaMatcher, on_alconna
 from nonebot_plugin_alconna.uniseg import At
 
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _BLOCK_MEMBER = COMMAND_TRIGGERS["block_member"]
@@ -28,6 +29,7 @@ block_member_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(block_member_cmd, "block_member")
 global_block_member_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(
         _GLOBAL_BLOCK_MEMBER.primary,
@@ -39,6 +41,7 @@ global_block_member_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(global_block_member_cmd, "global_block_member")
 unblock_member_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(
         _UNBLOCK_MEMBER.primary,
@@ -50,6 +53,7 @@ unblock_member_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(unblock_member_cmd, "unblock_member")
 global_unblock_member_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(
         _GLOBAL_UNBLOCK_MEMBER.primary,
@@ -61,6 +65,7 @@ global_unblock_member_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(global_unblock_member_cmd, "global_unblock_member")
 clear_blocklist_cmd: type[Matcher] = on_alconna(
     command=Alconna(_CLEAR_BLOCKLIST.primary, Args["reason?", str, None]),
     aliases=_CLEAR_BLOCKLIST.aliases,
@@ -69,6 +74,7 @@ clear_blocklist_cmd: type[Matcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(clear_blocklist_cmd, "clear_blocklist")
 global_clear_blocklist_cmd: type[Matcher] = on_alconna(
     command=Alconna(_GLOBAL_CLEAR_BLOCKLIST.primary, Args["reason?", str, None]),
     aliases=_GLOBAL_CLEAR_BLOCKLIST.aliases,
@@ -77,6 +83,7 @@ global_clear_blocklist_cmd: type[Matcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(global_clear_blocklist_cmd, "global_clear_blocklist")
 
 _LAZY_EXPORTS = {
     "onebot11_block_member": "..onebot.v11.default.group.block",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/command_triggers.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/command_triggers.py
@@ -41,6 +41,12 @@ COMMAND_TRIGGERS = {
         chinese_aliases=frozenset({"帮助", "功能", "功能列表", "指令", "命令列表"}),
         english_aliases=frozenset({"help", "commands"}),
     ),
+    "permission": CommandTrigger(
+        chinese="权限",
+        english="permission",
+        chinese_aliases=frozenset({"权限管理", "授权"}),
+        english_aliases=frozenset({"perm", "permissions"}),
+    ),
     "member_mute": CommandTrigger(
         chinese="禁言",
         english="mute",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/common.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/common.py
@@ -1,10 +1,17 @@
 from collections.abc import Awaitable, Callable
+from functools import wraps
 from typing import Any
 
+from nonebot.adapters import Bot, Event
 from nonebot.internal.matcher.matcher import Matcher
 from nonebot_plugin_alconna import AlconnaMatcher
 
 from ....platforms import is_adapter_enabled
+from ....services.permissions import (
+    check_permission,
+    command_key_for,
+    permission_context_from_event,
+)
 
 type GroupCommand = type[AlconnaMatcher | Matcher]
 type GroupHandler = Callable[..., Awaitable[Any]]
@@ -18,7 +25,51 @@ def selected_adapter_handle(
 
     def decorator(func: GroupHandler) -> GroupHandler:
         if is_adapter_enabled(adapter_id):
-            command.handle()(func)
+            command.handle()(_permission_guard(command, adapter_id, func))
         return func
 
     return decorator
+
+
+def _permission_guard(
+    command: GroupCommand,
+    adapter_id: str,
+    func: GroupHandler,
+) -> GroupHandler:
+    command_key = command_key_for(command)
+    if command_key is None or command_key == "permission":
+        return func
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bot = _find_arg(Bot, args, kwargs)
+        event = _find_arg(Event, args, kwargs)
+        if bot is None or event is None:
+            return await func(*args, **kwargs)
+
+        context = permission_context_from_event(
+            bot=bot,
+            event=event,
+            adapter_id=adapter_id,
+            command_key=command_key,
+        )
+        decision = await check_permission(context)
+        if not decision.allowed:
+            return await command.finish(message=f"权限不足: {decision.reason}")
+        return await func(*args, **kwargs)
+
+    return wrapper
+
+
+def _find_arg(
+    expected_type: type[Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any | None:
+    for value in kwargs.values():
+        if isinstance(value, expected_type):
+            return value
+    for value in args:
+        if isinstance(value, expected_type):
+            return value
+    return None

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/common.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/common.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import Any
 
+from nonebot import logger
 from nonebot.adapters import Bot, Event
 from nonebot.internal.matcher.matcher import Matcher
 from nonebot_plugin_alconna import AlconnaMatcher
@@ -45,7 +46,11 @@ def _permission_guard(
         bot = _find_arg(Bot, args, kwargs)
         event = _find_arg(Event, args, kwargs)
         if bot is None or event is None:
-            return await func(*args, **kwargs)
+            logger.error(
+                "Permission guard failed closed for %s: bot or event missing",
+                command_key,
+            )
+            return await command.finish(message="系统错误：无法验证权限")
 
         context = permission_context_from_event(
             bot=bot,

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/lifecycle.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/lifecycle.py
@@ -7,6 +7,7 @@ from nonebot.internal.matcher.matcher import Matcher
 from nonebot_plugin_alconna import on_alconna
 
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _LEAVE_GROUP = COMMAND_TRIGGERS["leave_group"]
@@ -19,6 +20,7 @@ quit_group_cmd: type[Matcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(quit_group_cmd, "leave_group")
 
 _LAZY_EXPORTS = {
     "milkybot_quit_group": "..milky.v1_2.default.group.lifecycle",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/member.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/member.py
@@ -7,6 +7,7 @@ from nonebot_plugin_alconna import AlconnaMatcher, on_alconna
 from nonebot_plugin_alconna.uniseg import At
 
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _SET_MEMBER_CARD = COMMAND_TRIGGERS["set_member_card"]
@@ -23,6 +24,7 @@ set_group_member_card_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(set_group_member_card_cmd, "set_member_card")
 set_group_member_special_title_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(_SET_MEMBER_TITLE.primary, Args["user", At]["special_title", str]),
     aliases=_SET_MEMBER_TITLE.aliases,
@@ -31,6 +33,7 @@ set_group_member_special_title_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(set_group_member_special_title_cmd, "set_member_title")
 set_group_member_admin_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(_SET_MEMBER_ADMIN.primary, Args["user", At]),
     aliases=_SET_MEMBER_ADMIN.aliases,
@@ -39,6 +42,7 @@ set_group_member_admin_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(set_group_member_admin_cmd, "set_member_admin")
 unset_group_member_admin_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(_UNSET_MEMBER_ADMIN.primary, Args["user", At]),
     aliases=_UNSET_MEMBER_ADMIN.aliases,
@@ -47,6 +51,7 @@ unset_group_member_admin_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(unset_group_member_admin_cmd, "unset_member_admin")
 kick_group_member_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(
         _KICK_MEMBER.primary,
@@ -58,6 +63,7 @@ kick_group_member_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(kick_group_member_cmd, "kick_member")
 
 _LAZY_EXPORTS = {
     "milkybot_set_group_member_card": "..milky.v1_2.default.group.member",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/mute.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/mute.py
@@ -8,6 +8,7 @@ from nonebot_plugin_alconna import AlconnaMatcher, on_alconna
 from nonebot_plugin_alconna.uniseg import At
 
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _MEMBER_MUTE = COMMAND_TRIGGERS["member_mute"]
@@ -26,6 +27,7 @@ member_mute_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(member_mute_cmd, "member_mute")
 whole_mute_cmd: type[Matcher] = on_alconna(
     command=Alconna(
         _WHOLE_MUTE.primary,
@@ -36,6 +38,7 @@ whole_mute_cmd: type[Matcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(whole_mute_cmd, "whole_mute")
 member_unmute_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(
         _MEMBER_UNMUTE.primary,
@@ -47,6 +50,7 @@ member_unmute_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(member_unmute_cmd, "member_unmute")
 
 whole_unmute_cmd: type[Matcher] = on_alconna(
     command=Alconna(
@@ -58,6 +62,7 @@ whole_unmute_cmd: type[Matcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(whole_unmute_cmd, "whole_unmute")
 
 _LAZY_EXPORTS = {
     "milkybot_mute": "..milky.v1_2.default.group.mute",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
@@ -80,7 +80,7 @@ async def _handle_permission(  # noqa: PLR0911, PLR0913
 
     normalized = action.casefold()
     if normalized in {"sync", "同步"}:
-        await ensure_default_permission_state()
+        await ensure_default_permission_state(force=True)
         return await permission_cmd.finish(message="权限树已同步")
 
     if normalized in {"tree", "list", "树", "列表"}:
@@ -122,19 +122,7 @@ async def _handle_permission(  # noqa: PLR0911, PLR0913
         return await permission_cmd.finish(message=message)
 
     if normalized in {"native-on", "native-off"}:
-        if not arg1:
-            return await permission_cmd.finish(
-                message="用法: 权限 native-on|native-off <owner|admin>"
-            )
-        await repository.set_native_role_mapping_enabled(
-            platform_id="qq",
-            adapter_id=None,
-            resource_type="group",
-            native_role=arg1,
-            is_enabled=normalized == "native-on",
-        )
-        state = "启用" if normalized == "native-on" else "禁用"
-        return await permission_cmd.finish(message=f"原生身份映射已{state}: {arg1}")
+        return await _finish_native_mapping(normalized, arg1)
 
     return await permission_cmd.finish(
         message=(
@@ -147,6 +135,25 @@ async def _handle_permission(  # noqa: PLR0911, PLR0913
             "- 权限 native-on|native-off <owner|admin>"
         )
     )
+
+
+async def _finish_native_mapping(action: str, native_role_text: str) -> Any:
+    if not native_role_text:
+        return await permission_cmd.finish(
+            message="用法: 权限 native-on|native-off <owner|admin>"
+        )
+    native_role = native_role_text.casefold()
+    if native_role not in {"owner", "admin"}:
+        return await permission_cmd.finish(message="无效的角色: 仅支持 owner 或 admin")
+    await repository.set_native_role_mapping_enabled(
+        platform_id="qq",
+        adapter_id=None,
+        resource_type="group",
+        native_role=native_role,
+        is_enabled=action == "native-on",
+    )
+    state = "启用" if action == "native-on" else "禁用"
+    return await permission_cmd.finish(message=f"原生身份映射已{state}: {native_role}")
 
 
 def _event_user_id(event: Event) -> str | None:

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
@@ -1,0 +1,162 @@
+from typing import Any
+
+from arclet.alconna import Alconna, Args
+from nonebot.adapters import Bot, Event
+from nonebot.internal.matcher.matcher import Matcher
+from nonebot_plugin_alconna import on_alconna
+
+from ....repositories import permissions as repository
+from ....services.permissions import (
+    add_group_member,
+    bind_command_key,
+    ensure_default_permission_state,
+    grant_group_to_node,
+    is_superuser,
+    list_tree_lines,
+)
+from .command_triggers import COMMAND_TRIGGERS
+from .common import selected_adapter_handle
+
+_PERMISSION = COMMAND_TRIGGERS["permission"]
+
+permission_cmd: type[Matcher] = on_alconna(
+    command=Alconna(
+        _PERMISSION.primary,
+        Args["action?", str, "help"]["arg1?", str, ""]["arg2?", str, ""][
+            "arg3?", str, ""
+        ]["arg4?", str, ""]["arg5?", str, ""],
+    ),
+    aliases=_PERMISSION.aliases,
+    priority=5,
+    block=True,
+    use_cmd_sep=True,
+    use_cmd_start=True,
+)
+bind_command_key(permission_cmd, "permission")
+
+
+@selected_adapter_handle(permission_cmd, "~onebot.v11")
+async def onebot11_permission(  # noqa: PLR0913
+    bot: Bot,
+    event: Event,
+    action: str = "help",
+    arg1: str = "",
+    arg2: str = "",
+    arg3: str = "",
+    arg4: str = "",
+    arg5: str = "",
+) -> Any:
+    return await _handle_permission(bot, event, action, arg1, arg2, arg3, arg4, arg5)
+
+
+@selected_adapter_handle(permission_cmd, "~milky")
+async def milky_permission(  # noqa: PLR0913
+    bot: Bot,
+    event: Event,
+    action: str = "help",
+    arg1: str = "",
+    arg2: str = "",
+    arg3: str = "",
+    arg4: str = "",
+    arg5: str = "",
+) -> Any:
+    return await _handle_permission(bot, event, action, arg1, arg2, arg3, arg4, arg5)
+
+
+async def _handle_permission(  # noqa: PLR0911, PLR0913
+    bot: Bot,
+    event: Event,
+    action: str,
+    arg1: str,
+    arg2: str,
+    arg3: str,
+    arg4: str,
+    arg5: str,
+) -> Any:
+    _ = bot
+    user_id = _event_user_id(event)
+    if not is_superuser(user_id):
+        return await permission_cmd.finish(message="权限不足: 仅 superusers 可管理权限")
+
+    normalized = action.casefold()
+    if normalized in {"sync", "同步"}:
+        await ensure_default_permission_state()
+        return await permission_cmd.finish(message="权限树已同步")
+
+    if normalized in {"tree", "list", "树", "列表"}:
+        lines = await list_tree_lines()
+        return await permission_cmd.finish(message="\n".join(["权限树", *lines]))
+
+    if normalized in {"grant", "授权"}:
+        if not arg1 or not arg2:
+            return await permission_cmd.finish(
+                message=(
+                    "用法: 权限 grant <group_key> <node_path> "
+                    "[resource_type] [resource_id]"
+                )
+            )
+        ok = await grant_group_to_node(
+            group_key=arg1,
+            node_path=arg2,
+            resource_type=arg3 or None,
+            resource_id=arg4 or None,
+        )
+        message = "授权已写入" if ok else "授权失败: 组或权限节点不存在"
+        return await permission_cmd.finish(message=message)
+
+    if normalized in {"member", "add-member", "成员"}:
+        if not arg1 or not arg2 or not arg3:
+            return await permission_cmd.finish(
+                message=(
+                    "用法: 权限 member <group_key> <platform_id> <user_id> "
+                    "[resource_type] [resource_id]"
+                )
+            )
+        ok = await add_group_member(
+            group_key=arg1,
+            platform_id=arg2,
+            user_id=arg3,
+            resource_type=arg4 or None,
+            resource_id=arg5 or None,
+        )
+        message = "成员已写入" if ok else "成员写入失败: 组不存在"
+        return await permission_cmd.finish(message=message)
+
+    if normalized in {"native-on", "native-off"}:
+        if not arg1:
+            return await permission_cmd.finish(
+                message="用法: 权限 native-on|native-off <owner|admin>"
+            )
+        await repository.set_native_role_mapping_enabled(
+            platform_id="qq",
+            adapter_id=None,
+            resource_type="group",
+            native_role=arg1,
+            is_enabled=normalized == "native-on",
+        )
+        state = "启用" if normalized == "native-on" else "禁用"
+        return await permission_cmd.finish(message=f"原生身份映射已{state}: {arg1}")
+
+    return await permission_cmd.finish(
+        message=(
+            "权限命令:\n"
+            "- 权限 sync\n"
+            "- 权限 tree\n"
+            "- 权限 grant <group_key> <node_path> [resource_type] [resource_id]\n"
+            "- 权限 member <group_key> <platform_id> <user_id> "
+            "[resource_type] [resource_id]\n"
+            "- 权限 native-on|native-off <owner|admin>"
+        )
+    )
+
+
+def _event_user_id(event: Event) -> str | None:
+    try:
+        return str(event.get_user_id())
+    except Exception:  # noqa: BLE001
+        value = getattr(event, "user_id", None)
+        return None if value is None else str(value)
+
+
+async def import_handle() -> Any:
+    return None

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
@@ -84,8 +84,7 @@ async def _handle_permission(  # noqa: PLR0911, PLR0913
         return await permission_cmd.finish(message="权限树已同步")
 
     if normalized in {"tree", "list", "树", "列表"}:
-        lines = await list_tree_lines()
-        return await permission_cmd.finish(message="\n".join(["权限树", *lines]))
+        return await _finish_permission_tree(arg1)
 
     if normalized in {"grant", "授权"}:
         if not arg1 or not arg2:
@@ -141,7 +140,7 @@ async def _handle_permission(  # noqa: PLR0911, PLR0913
         message=(
             "权限命令:\n"
             "- 权限 sync\n"
-            "- 权限 tree\n"
+            "- 权限 tree [数量]\n"
             "- 权限 grant <group_key> <node_path> [resource_type] [resource_id]\n"
             "- 权限 member <group_key> <platform_id> <user_id> "
             "[resource_type] [resource_id]\n"
@@ -156,6 +155,26 @@ def _event_user_id(event: Event) -> str | None:
     except Exception:  # noqa: BLE001
         value = getattr(event, "user_id", None)
         return None if value is None else str(value)
+
+
+async def _finish_permission_tree(limit_text: str) -> Any:
+    limit = _parse_positive_limit(limit_text)
+    if limit is None and limit_text:
+        return await permission_cmd.finish(
+            message="无效的数量参数: 请使用正整数，例如: 权限 tree 200"
+        )
+    lines = await list_tree_lines(limit=limit or 80)
+    return await permission_cmd.finish(message="\n".join(["权限树", *lines]))
+
+
+def _parse_positive_limit(value: str) -> int | None:
+    if not value:
+        return None
+    try:
+        limit = int(value)
+    except ValueError:
+        return None
+    return limit if limit > 0 else None
 
 
 async def import_handle() -> Any:

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/permission.py
@@ -145,13 +145,17 @@ async def _finish_native_mapping(action: str, native_role_text: str) -> Any:
     native_role = native_role_text.casefold()
     if native_role not in {"owner", "admin"}:
         return await permission_cmd.finish(message="无效的角色: 仅支持 owner 或 admin")
-    await repository.set_native_role_mapping_enabled(
+    updated_count, _ = await repository.set_native_role_mapping_enabled(
         platform_id="qq",
         adapter_id=None,
         resource_type="group",
         native_role=native_role,
         is_enabled=action == "native-on",
     )
+    if updated_count == 0:
+        return await permission_cmd.finish(
+            message=f"原生身份映射未找到，请先执行 权限 sync: {native_role}"
+        )
     state = "启用" if action == "native-on" else "禁用"
     return await permission_cmd.finish(message=f"原生身份映射已{state}: {native_role}")
 

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/profile.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/group/profile.py
@@ -12,6 +12,7 @@ from nonebot_plugin_alconna.uniseg import Image as UniImage
 
 from ....core.config import plugin_config
 from ....i18n import _async as _
+from ....services.permissions import bind_command_key
 from .command_triggers import COMMAND_TRIGGERS
 
 _SET_GROUP_NAME = COMMAND_TRIGGERS["set_group_name"]
@@ -62,6 +63,7 @@ set_group_name_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(set_group_name_cmd, "set_group_name")
 set_group_avatar_cmd: type[AlconnaMatcher] = on_alconna(
     command=Alconna(_SET_GROUP_AVATAR.primary, Args["image", UniImage | None]),
     aliases=_SET_GROUP_AVATAR.aliases,
@@ -70,6 +72,7 @@ set_group_avatar_cmd: type[AlconnaMatcher] = on_alconna(
     use_cmd_sep=True,
     use_cmd_start=True,
 )
+bind_command_key(set_group_avatar_cmd, "set_group_avatar")
 
 _LAZY_EXPORTS = {
     "milkybot_set_group_name": "..milky.v1_2.default.group.profile",

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/group/__init__.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/group/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from .....group import permission as permission
 from . import announcement as announcement
 from . import lifecycle as lifecycle
 from . import member as member

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/menu.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/menu.py
@@ -2,8 +2,10 @@ from typing import Any
 
 from nonebot import logger
 from nonebot.adapters.milky import Bot as MilkyBot
+from nonebot.adapters.milky.event import Event as MilkyEvent
 from nonebot.adapters.milky.exception import ActionFailed, NetworkError
 
+from ......services.permissions import PermissionContext, visible_command_keys
 from .....menu import (
     MILKY_ADAPTER_ID,
     menu_cmd,
@@ -18,18 +20,30 @@ milkybot_menu_pages: dict[str, Any] = {}
 
 
 @selected_adapter_handle(menu_cmd, "~milky")
-async def milkybot_menu(bot: MilkyBot) -> Any:
+async def milkybot_menu(
+    bot: MilkyBot,
+    event: MilkyEvent | None = None,
+) -> Any:
     context = await _milky_menu_context(bot)
-    return await menu_cmd.finish(message=render_menu_index(context))
+    allowed = await _visible_commands(bot, context, event)
+    return await menu_cmd.finish(
+        message=render_menu_index(context, allowed_command_keys=allowed)
+    )
 
 
 def _register_milky_menu_page(page_id: str) -> None:
     command = menu_page_cmds[page_id]
 
     @selected_adapter_handle(command, "~milky")
-    async def milkybot_menu_page(bot: MilkyBot) -> Any:
+    async def milkybot_menu_page(
+        bot: MilkyBot,
+        event: MilkyEvent | None = None,
+    ) -> Any:
         context = await _milky_menu_context(bot)
-        return await command.finish(message=render_menu_page(page_id, context))
+        allowed = await _visible_commands(bot, context, event)
+        return await command.finish(
+            message=render_menu_page(page_id, context, allowed_command_keys=allowed)
+        )
 
     milkybot_menu_pages[page_id] = milkybot_menu_page
 
@@ -60,6 +74,47 @@ def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+async def _visible_commands(
+    bot: MilkyBot,
+    context: Any,
+    event: MilkyEvent | None,
+) -> frozenset[str] | None:
+    if event is None:
+        return None
+    resource_id = _event_resource_id(event)
+    permission_context = PermissionContext(
+        platform_id=context.platform_id,
+        adapter_id=context.adapter_id,
+        implementation_name=context.implementation_name,
+        command_key="menu",
+        user_id=_event_user_id(event),
+        bot_id=_string_or_none(getattr(bot, "self_id", None)),
+        resource_type="group" if resource_id is not None else None,
+        resource_id=resource_id,
+        native_roles=_event_native_roles(event),
+    )
+    return await visible_command_keys(permission_context)
+
+
+def _event_resource_id(event: MilkyEvent) -> str | None:
+    data = getattr(event, "data", None)
+    return _string_or_none(getattr(data, "peer_id", None))
+
+
+def _event_user_id(event: MilkyEvent) -> str | None:
+    try:
+        return str(event.get_user_id())
+    except Exception:  # noqa: BLE001
+        data = getattr(event, "data", None)
+        return _string_or_none(getattr(data, "user_id", None))
+
+
+def _event_native_roles(event: MilkyEvent) -> frozenset[str]:
+    data = getattr(event, "data", None)
+    role = getattr(data, "sender_role", None)
+    return frozenset({str(role)}) if role is not None else frozenset()
 
 
 async def import_handle() -> Any:

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/menu.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/milky/v1_2/default/menu.py
@@ -114,7 +114,16 @@ def _event_user_id(event: MilkyEvent) -> str | None:
 def _event_native_roles(event: MilkyEvent) -> frozenset[str]:
     data = getattr(event, "data", None)
     role = getattr(data, "sender_role", None)
-    return frozenset({str(role)}) if role is not None else frozenset()
+    return _normalize_native_role(role)
+
+
+def _normalize_native_role(role: Any) -> frozenset[str]:
+    normalized = str(role).casefold() if role is not None else ""
+    if normalized in {"owner", "admin", "administrator"}:
+        return frozenset({"admin" if normalized == "administrator" else normalized})
+    if normalized in {"member", ""}:
+        return frozenset()
+    return frozenset({normalized})
 
 
 async def import_handle() -> Any:

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/group/__init__.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/group/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from .....group import permission as permission
 from . import announcement as announcement
 from . import block as block
 from . import lifecycle as lifecycle

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/menu.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/menu.py
@@ -2,8 +2,13 @@ from typing import Any
 
 from nonebot import logger
 from nonebot.adapters.onebot.v11 import Bot as OneBot11Bot
+from nonebot.adapters.onebot.v11.event import Event as OneBot11Event
 from nonebot.adapters.onebot.v11.exception import ActionFailed as OneBot11ActionFailed
 
+from ......services.permissions import (
+    PermissionContext,
+    visible_command_keys,
+)
 from .....menu import (
     ONEBOT_V11_ADAPTER_ID,
     menu_cmd,
@@ -18,18 +23,30 @@ onebot11_menu_pages: dict[str, Any] = {}
 
 
 @selected_adapter_handle(menu_cmd, "~onebot.v11")
-async def onebot11_menu(bot: OneBot11Bot) -> Any:
+async def onebot11_menu(
+    bot: OneBot11Bot,
+    event: OneBot11Event | None = None,
+) -> Any:
     context = await _onebot11_menu_context(bot)
-    return await menu_cmd.finish(message=render_menu_index(context))
+    allowed = await _visible_commands(bot, context, event)
+    return await menu_cmd.finish(
+        message=render_menu_index(context, allowed_command_keys=allowed)
+    )
 
 
 def _register_onebot11_menu_page(page_id: str) -> None:
     command = menu_page_cmds[page_id]
 
     @selected_adapter_handle(command, "~onebot.v11")
-    async def onebot11_menu_page(bot: OneBot11Bot) -> Any:
+    async def onebot11_menu_page(
+        bot: OneBot11Bot,
+        event: OneBot11Event | None = None,
+    ) -> Any:
         context = await _onebot11_menu_context(bot)
-        return await command.finish(message=render_menu_page(page_id, context))
+        allowed = await _visible_commands(bot, context, event)
+        return await command.finish(
+            message=render_menu_page(page_id, context, allowed_command_keys=allowed)
+        )
 
     onebot11_menu_pages[page_id] = onebot11_menu_page
 
@@ -59,6 +76,40 @@ def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+async def _visible_commands(
+    bot: OneBot11Bot,
+    context: Any,
+    event: OneBot11Event | None,
+) -> frozenset[str] | None:
+    if event is None:
+        return None
+    permission_context = PermissionContext(
+        platform_id=context.platform_id,
+        adapter_id=context.adapter_id,
+        implementation_name=context.implementation_name,
+        command_key="menu",
+        user_id=_event_user_id(event),
+        bot_id=_string_or_none(getattr(bot, "self_id", None)),
+        resource_type="group" if getattr(event, "group_id", None) is not None else None,
+        resource_id=_string_or_none(getattr(event, "group_id", None)),
+        native_roles=_event_native_roles(event),
+    )
+    return await visible_command_keys(permission_context)
+
+
+def _event_user_id(event: OneBot11Event) -> str | None:
+    try:
+        return str(event.get_user_id())
+    except Exception:  # noqa: BLE001
+        return _string_or_none(getattr(event, "user_id", None))
+
+
+def _event_native_roles(event: OneBot11Event) -> frozenset[str]:
+    sender = getattr(event, "sender", None)
+    role = getattr(sender, "role", None)
+    return frozenset({str(role)}) if role is not None else frozenset()
 
 
 async def import_handle() -> Any:

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/menu.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/onebot/v11/default/menu.py
@@ -109,7 +109,16 @@ def _event_user_id(event: OneBot11Event) -> str | None:
 def _event_native_roles(event: OneBot11Event) -> frozenset[str]:
     sender = getattr(event, "sender", None)
     role = getattr(sender, "role", None)
-    return frozenset({str(role)}) if role is not None else frozenset()
+    return _normalize_native_role(role)
+
+
+def _normalize_native_role(role: Any) -> frozenset[str]:
+    normalized = str(role).casefold() if role is not None else ""
+    if normalized in {"owner", "admin", "administrator"}:
+        return frozenset({"admin" if normalized == "administrator" else normalized})
+    if normalized in {"member", ""}:
+        return frozenset()
+    return frozenset({normalized})
 
 
 async def import_handle() -> Any:

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -554,10 +554,10 @@ async def visible_command_keys_for_context(  # noqa: PLR0913
             )
             .order_by(PermissionNode.id.desc())
         )
-        command_nodes: dict[str, PermissionNode] = {}
-        for node in (await session.execute(node_stmt)).scalars():
-            if node.command_key is not None:
-                command_nodes.setdefault(node.command_key, node)
+        command_nodes = _select_command_nodes(
+            (await session.execute(node_stmt)).scalars(),
+            implementation_name,
+        )
         if not command_nodes:
             return frozenset()
 
@@ -718,6 +718,36 @@ def _node_covers(grant_node: PermissionNode, target_node: PermissionNode) -> boo
     return target_node.path == grant_node.path or target_node.path.startswith(
         f"{grant_node.path}/"
     )
+
+
+def _select_command_nodes(
+    nodes: Iterable[PermissionNode],
+    implementation_name: str | None,
+) -> dict[str, PermissionNode]:
+    command_nodes: dict[str, PermissionNode] = {}
+    for node in nodes:
+        if node.command_key is None:
+            continue
+        current = command_nodes.get(node.command_key)
+        if current is None or _implementation_rank(
+            getattr(node, "implementation_name", None),
+            implementation_name,
+        ) > _implementation_rank(
+            getattr(current, "implementation_name", None),
+            implementation_name,
+        ):
+            command_nodes[node.command_key] = node
+    return command_nodes
+
+
+def _implementation_rank(value: str | None, target: str | None) -> int:
+    if target is not None and value == target:
+        return 2
+    if value == DEFAULT_IMPLEMENTATION:
+        return 1
+    if value is None:
+        return 0
+    return -1
 
 
 def _stored_scope(value: str | None) -> str:

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -458,6 +458,10 @@ async def find_matching_grant(  # noqa: PLR0913
         ]
 
         if native_roles:
+            # Native role mappings intentionally define how a platform role label maps
+            # to an internal group for the whole resource type. Concrete scope still
+            # comes from the event's native role on the current resource plus grant
+            # resource_type/resource_id matching below.
             native_stmt = (
                 select(PermissionGroup)
                 .join(

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -117,9 +117,10 @@ async def get_command_node(
         PermissionNode,
         conditions=conditions,
         order_by=["-id"],
-        limit=1,
+        limit=100,
     )
-    return items[0] if items else None
+    command_nodes = _select_command_nodes(items, implementation_name)
+    return command_nodes.get(command_key)
 
 
 async def list_permission_nodes(limit: int = 200) -> list[PermissionNode]:

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -453,7 +453,9 @@ async def find_matching_grant(  # noqa: PLR0913
             )
             .order_by(PermissionGroup.priority.desc())
         )
-        groups = [row[0] for row in (await session.execute(member_stmt)).all()]
+        groups: list[PermissionGroup] = [
+            row[0] for row in (await session.execute(member_stmt)).all()
+        ]
 
         if native_roles:
             native_stmt = (
@@ -477,35 +479,39 @@ async def find_matching_grant(  # noqa: PLR0913
             )
             groups.extend((await session.execute(native_stmt)).scalars())
 
-        for group in groups:
-            grant_stmt = (
-                select(PermissionGrant, PermissionNode)
-                .join(PermissionNode, PermissionGrant.node_id == PermissionNode.id)
-                .where(
-                    PermissionGrant.group_id == group.id,
-                    PermissionGrant.is_enabled.is_(True),
-                    PermissionNode.is_enabled.is_(True),
-                    or_(
-                        PermissionGrant.resource_type == DEFAULT_VALUE,
-                        PermissionGrant.resource_type == resource_type,
-                    ),
-                    or_(
-                        PermissionGrant.resource_id == DEFAULT_VALUE,
-                        PermissionGrant.resource_id == resource_id,
-                    ),
-                    or_(
-                        PermissionGrant.expires_at.is_(None),
-                        PermissionGrant.expires_at > now,
-                    ),
-                )
-                .order_by(PermissionNode.path)
+        group_ids = list(dict.fromkeys(group.id for group in groups))
+        if not group_ids:
+            return None, None, None
+
+        grant_stmt = (
+            select(PermissionGroup, PermissionGrant, PermissionNode)
+            .join(PermissionGrant, PermissionGroup.id == PermissionGrant.group_id)
+            .join(PermissionNode, PermissionGrant.node_id == PermissionNode.id)
+            .where(
+                PermissionGroup.id.in_(group_ids),
+                PermissionGrant.is_enabled.is_(True),
+                PermissionNode.is_enabled.is_(True),
+                or_(
+                    PermissionGrant.resource_type == DEFAULT_VALUE,
+                    PermissionGrant.resource_type == resource_type,
+                ),
+                or_(
+                    PermissionGrant.resource_id == DEFAULT_VALUE,
+                    PermissionGrant.resource_id == resource_id,
+                ),
+                or_(
+                    PermissionGrant.expires_at.is_(None),
+                    PermissionGrant.expires_at > now,
+                ),
             )
-            grants = (await session.execute(grant_stmt)).all()
-            for grant, node in grants:
-                if target_node.path == node.path or target_node.path.startswith(
-                    f"{node.path}/"
-                ):
-                    return group, grant, node
+            .order_by(PermissionGroup.priority.desc(), PermissionNode.path)
+        )
+        grants = (await session.execute(grant_stmt)).all()
+        for group, grant, node in grants:
+            if target_node.path == node.path or target_node.path.startswith(
+                f"{node.path}/"
+            ):
+                return group, grant, node
     return None, None, None
 
 

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -1,0 +1,539 @@
+"""Repository helpers for Lingchu's internal permission center."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from nonebot_plugin_orm import get_session
+from sqlalchemy import or_, select
+
+from ..database.models import (
+    CapabilityContract,
+    NativeRoleMapping,
+    PermissionAuditLog,
+    PermissionGrant,
+    PermissionGroup,
+    PermissionGroupMember,
+    PermissionNode,
+)
+from ..database.orm_crud import create, delete, get_one, list_items, upsert
+from ..database.orm_crud import update as update_rows
+
+DEFAULT_OWNER_GROUP_KEY = "native-owner"
+DEFAULT_ADMIN_GROUP_KEY = "native-admin"
+DEFAULT_VALUE = "*"
+DEFAULT_IMPLEMENTATION = "default"
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def upsert_node(  # noqa: PLR0913
+    *,
+    path: str,
+    parent_id: int | None,
+    kind: str,
+    title: str | None = None,
+    platform_id: str | None = None,
+    adapter_id: str | None = None,
+    implementation_name: str | None = None,
+    command_key: str | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    is_builtin: bool = True,
+    is_enabled: bool = True,
+) -> PermissionNode:
+    now = utc_now()
+    values = {
+        "path": path,
+        "parent_id": parent_id,
+        "kind": kind,
+        "platform_id": platform_id,
+        "adapter_id": adapter_id,
+        "implementation_name": implementation_name,
+        "command_key": command_key,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "title": title,
+        "is_builtin": is_builtin,
+        "is_enabled": is_enabled,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await upsert(
+        PermissionNode,
+        values,
+        conflict_fields=["path"],
+        update_values={
+            "parent_id": parent_id,
+            "kind": kind,
+            "platform_id": platform_id,
+            "adapter_id": adapter_id,
+            "implementation_name": implementation_name,
+            "command_key": command_key,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "title": title,
+            "is_builtin": is_builtin,
+            "is_enabled": is_enabled,
+            "updated_at": now,
+        },
+    )
+    node = await get_node_by_path(path)
+    if node is None:
+        msg = f"permission node upsert did not return a row: {path}"
+        raise RuntimeError(msg)
+    return node
+
+
+async def get_node_by_path(path: str) -> PermissionNode | None:
+    return await get_one(PermissionNode, {"path": path})
+
+
+async def get_command_node(
+    *,
+    platform_id: str,
+    adapter_id: str,
+    command_key: str,
+    implementation_name: str | None = None,
+) -> PermissionNode | None:
+    conditions = [
+        PermissionNode.platform_id == platform_id,
+        PermissionNode.adapter_id == adapter_id,
+        PermissionNode.command_key == command_key,
+        PermissionNode.is_enabled.is_(True),
+        or_(
+            PermissionNode.implementation_name.is_(None),
+            PermissionNode.implementation_name == DEFAULT_IMPLEMENTATION,
+            PermissionNode.implementation_name == implementation_name,
+        ),
+    ]
+    items = await list_items(
+        PermissionNode,
+        conditions=conditions,
+        order_by=["-id"],
+        limit=1,
+    )
+    return items[0] if items else None
+
+
+async def list_permission_nodes(limit: int = 200) -> list[PermissionNode]:
+    return await list_items(PermissionNode, order_by=["path"], limit=limit)
+
+
+async def upsert_group(  # noqa: PLR0913
+    *,
+    key: str,
+    name: str,
+    parent_id: int | None = None,
+    priority: int = 0,
+    is_builtin: bool = False,
+    is_enabled: bool = True,
+) -> PermissionGroup:
+    now = utc_now()
+    await upsert(
+        PermissionGroup,
+        {
+            "key": key,
+            "name": name,
+            "parent_id": parent_id,
+            "priority": priority,
+            "is_builtin": is_builtin,
+            "is_enabled": is_enabled,
+            "created_at": now,
+            "updated_at": now,
+        },
+        conflict_fields=["key"],
+        update_values={
+            "name": name,
+            "parent_id": parent_id,
+            "priority": priority,
+            "is_builtin": is_builtin,
+            "is_enabled": is_enabled,
+            "updated_at": now,
+        },
+    )
+    group = await get_group_by_key(key)
+    if group is None:
+        msg = f"permission group upsert did not return a row: {key}"
+        raise RuntimeError(msg)
+    return group
+
+
+async def get_group_by_key(key: str) -> PermissionGroup | None:
+    return await get_one(PermissionGroup, {"key": key})
+
+
+async def upsert_member(  # noqa: PLR0913
+    *,
+    group_id: int,
+    platform_id: str,
+    user_id: str,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    expires_at: datetime | None = None,
+) -> PermissionGroupMember:
+    now = utc_now()
+    stored_resource_type = _stored_scope(resource_type)
+    stored_resource_id = _stored_scope(resource_id)
+    values = {
+        "group_id": group_id,
+        "platform_id": platform_id,
+        "user_id": user_id,
+        "resource_type": stored_resource_type,
+        "resource_id": stored_resource_id,
+        "expires_at": expires_at,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await upsert(
+        PermissionGroupMember,
+        values,
+        conflict_fields=[
+            "group_id",
+            "platform_id",
+            "user_id",
+            "resource_type",
+            "resource_id",
+        ],
+        update_values={"expires_at": expires_at, "updated_at": now},
+    )
+    member = await get_one(
+        PermissionGroupMember,
+        {
+            "group_id": group_id,
+            "platform_id": platform_id,
+            "user_id": user_id,
+            "resource_type": stored_resource_type,
+            "resource_id": stored_resource_id,
+        },
+    )
+    if member is None:
+        msg = "permission group member upsert did not return a row"
+        raise RuntimeError(msg)
+    return member
+
+
+async def remove_member(
+    *,
+    group_id: int,
+    platform_id: str,
+    user_id: str,
+    resource_type: str | None,
+    resource_id: str | None,
+) -> tuple[int, bool]:
+    stored_resource_type = _stored_scope(resource_type)
+    stored_resource_id = _stored_scope(resource_id)
+    return await delete(
+        PermissionGroupMember,
+        {
+            "group_id": group_id,
+            "platform_id": platform_id,
+            "user_id": user_id,
+            "resource_type": stored_resource_type,
+            "resource_id": stored_resource_id,
+        },
+    )
+
+
+async def upsert_grant(  # noqa: PLR0913
+    *,
+    group_id: int,
+    node_id: int,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    is_enabled: bool = True,
+    expires_at: datetime | None = None,
+) -> PermissionGrant:
+    now = utc_now()
+    stored_resource_type = _stored_scope(resource_type)
+    stored_resource_id = _stored_scope(resource_id)
+    values = {
+        "group_id": group_id,
+        "node_id": node_id,
+        "resource_type": stored_resource_type,
+        "resource_id": stored_resource_id,
+        "is_enabled": is_enabled,
+        "expires_at": expires_at,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await upsert(
+        PermissionGrant,
+        values,
+        conflict_fields=["group_id", "node_id", "resource_type", "resource_id"],
+        update_values={
+            "is_enabled": is_enabled,
+            "expires_at": expires_at,
+            "updated_at": now,
+        },
+    )
+    grant = await get_one(
+        PermissionGrant,
+        {
+            "group_id": group_id,
+            "node_id": node_id,
+            "resource_type": stored_resource_type,
+            "resource_id": stored_resource_id,
+        },
+    )
+    if grant is None:
+        msg = "permission grant upsert did not return a row"
+        raise RuntimeError(msg)
+    return grant
+
+
+async def upsert_capability_contract(  # noqa: PLR0913
+    *,
+    platform_id: str,
+    adapter_id: str,
+    command_key: str,
+    capability: str,
+    implementation_name: str | None = None,
+    minimum_version: str | None = None,
+    protocol_version: str | None = None,
+    is_enabled: bool = True,
+) -> CapabilityContract:
+    now = utc_now()
+    stored_implementation_name = implementation_name or DEFAULT_IMPLEMENTATION
+    values = {
+        "platform_id": platform_id,
+        "adapter_id": adapter_id,
+        "implementation_name": stored_implementation_name,
+        "command_key": command_key,
+        "capability": capability,
+        "minimum_version": minimum_version,
+        "protocol_version": protocol_version,
+        "is_enabled": is_enabled,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await upsert(
+        CapabilityContract,
+        values,
+        conflict_fields=[
+            "platform_id",
+            "adapter_id",
+            "implementation_name",
+            "command_key",
+        ],
+        update_values={
+            "capability": capability,
+            "minimum_version": minimum_version,
+            "protocol_version": protocol_version,
+            "is_enabled": is_enabled,
+            "updated_at": now,
+        },
+    )
+    contract = await get_one(
+        CapabilityContract,
+        {
+            "platform_id": platform_id,
+            "adapter_id": adapter_id,
+            "implementation_name": stored_implementation_name,
+            "command_key": command_key,
+        },
+    )
+    if contract is None:
+        msg = "capability contract upsert did not return a row"
+        raise RuntimeError(msg)
+    return contract
+
+
+async def upsert_native_role_mapping(  # noqa: PLR0913
+    *,
+    platform_id: str,
+    adapter_id: str | None,
+    resource_type: str,
+    native_role: str,
+    group_id: int | None,
+    is_enabled: bool = True,
+) -> NativeRoleMapping:
+    now = utc_now()
+    stored_adapter_id = adapter_id or DEFAULT_VALUE
+    values = {
+        "platform_id": platform_id,
+        "adapter_id": stored_adapter_id,
+        "resource_type": resource_type,
+        "native_role": native_role,
+        "group_id": group_id,
+        "is_enabled": is_enabled,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await upsert(
+        NativeRoleMapping,
+        values,
+        conflict_fields=["platform_id", "adapter_id", "resource_type", "native_role"],
+        update_values={
+            "group_id": group_id,
+            "is_enabled": is_enabled,
+            "updated_at": now,
+        },
+    )
+    mapping = await get_one(
+        NativeRoleMapping,
+        {
+            "platform_id": platform_id,
+            "adapter_id": stored_adapter_id,
+            "resource_type": resource_type,
+            "native_role": native_role,
+        },
+    )
+    if mapping is None:
+        msg = "native role mapping upsert did not return a row"
+        raise RuntimeError(msg)
+    return mapping
+
+
+async def set_native_role_mapping_enabled(
+    *,
+    platform_id: str,
+    adapter_id: str | None,
+    resource_type: str,
+    native_role: str,
+    is_enabled: bool,
+) -> tuple[int, bool]:
+    stored_adapter_id = adapter_id or DEFAULT_VALUE
+    return await update_rows(
+        NativeRoleMapping,
+        {
+            "platform_id": platform_id,
+            "adapter_id": stored_adapter_id,
+            "resource_type": resource_type,
+            "native_role": native_role,
+        },
+        {"is_enabled": is_enabled, "updated_at": utc_now()},
+    )
+
+
+async def create_audit_log(**fields: Any) -> PermissionAuditLog:
+    return await create(
+        PermissionAuditLog,
+        created_at=utc_now(),
+        **fields,
+    )
+
+
+async def find_matching_grant(  # noqa: PLR0913
+    *,
+    platform_id: str,
+    user_id: str,
+    target_node: PermissionNode,
+    resource_type: str | None,
+    resource_id: str | None,
+    native_roles: frozenset[str] = frozenset(),
+) -> tuple[PermissionGroup | None, PermissionGrant | None, PermissionNode | None]:
+    now = utc_now()
+    async with get_session() as session:
+        member_stmt = (
+            select(PermissionGroup, PermissionGroupMember)
+            .join(
+                PermissionGroupMember,
+                PermissionGroup.id == PermissionGroupMember.group_id,
+            )
+            .where(
+                PermissionGroup.is_enabled.is_(True),
+                PermissionGroupMember.platform_id == platform_id,
+                PermissionGroupMember.user_id == user_id,
+                or_(
+                    PermissionGroupMember.resource_type == DEFAULT_VALUE,
+                    PermissionGroupMember.resource_type == resource_type,
+                ),
+                or_(
+                    PermissionGroupMember.resource_id == DEFAULT_VALUE,
+                    PermissionGroupMember.resource_id == resource_id,
+                ),
+                or_(
+                    PermissionGroupMember.expires_at.is_(None),
+                    PermissionGroupMember.expires_at > now,
+                ),
+            )
+            .order_by(PermissionGroup.priority.desc())
+        )
+        groups = [row[0] for row in (await session.execute(member_stmt)).all()]
+
+        if native_roles:
+            native_stmt = (
+                select(PermissionGroup)
+                .join(
+                    NativeRoleMapping,
+                    PermissionGroup.id == NativeRoleMapping.group_id,
+                )
+                .where(
+                    PermissionGroup.is_enabled.is_(True),
+                    NativeRoleMapping.platform_id == platform_id,
+                    or_(
+                        NativeRoleMapping.adapter_id == DEFAULT_VALUE,
+                        NativeRoleMapping.adapter_id == target_node.adapter_id,
+                    ),
+                    NativeRoleMapping.resource_type == (resource_type or "global"),
+                    NativeRoleMapping.native_role.in_(native_roles),
+                    NativeRoleMapping.is_enabled.is_(True),
+                )
+                .order_by(PermissionGroup.priority.desc())
+            )
+            groups.extend((await session.execute(native_stmt)).scalars())
+
+        for group in groups:
+            grant_stmt = (
+                select(PermissionGrant, PermissionNode)
+                .join(PermissionNode, PermissionGrant.node_id == PermissionNode.id)
+                .where(
+                    PermissionGrant.group_id == group.id,
+                    PermissionGrant.is_enabled.is_(True),
+                    PermissionNode.is_enabled.is_(True),
+                    or_(
+                        PermissionGrant.resource_type == DEFAULT_VALUE,
+                        PermissionGrant.resource_type == resource_type,
+                    ),
+                    or_(
+                        PermissionGrant.resource_id == DEFAULT_VALUE,
+                        PermissionGrant.resource_id == resource_id,
+                    ),
+                    or_(
+                        PermissionGrant.expires_at.is_(None),
+                        PermissionGrant.expires_at > now,
+                    ),
+                )
+                .order_by(PermissionNode.path)
+            )
+            grants = (await session.execute(grant_stmt)).all()
+            for grant, node in grants:
+                if target_node.path == node.path or target_node.path.startswith(
+                    f"{node.path}/"
+                ):
+                    return group, grant, node
+    return None, None, None
+
+
+async def capability_contract_allows(
+    *,
+    platform_id: str,
+    adapter_id: str,
+    command_key: str,
+    implementation_name: str | None,
+) -> bool:
+    contracts = await list_items(
+        CapabilityContract,
+        {
+            "platform_id": platform_id,
+            "adapter_id": adapter_id,
+            "command_key": command_key,
+        },
+        limit=100,
+    )
+    if not contracts:
+        return True
+    return any(
+        contract.is_enabled
+        and contract.implementation_name
+        in {DEFAULT_IMPLEMENTATION, implementation_name}
+        for contract in contracts
+    )
+
+
+def _stored_scope(value: str | None) -> str:
+    return value or DEFAULT_VALUE

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/permissions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nonebot_plugin_orm import get_session
 from sqlalchemy import or_, select
@@ -24,6 +24,9 @@ DEFAULT_OWNER_GROUP_KEY = "native-owner"
 DEFAULT_ADMIN_GROUP_KEY = "native-admin"
 DEFAULT_VALUE = "*"
 DEFAULT_IMPLEMENTATION = "default"
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def utc_now() -> datetime:
@@ -519,6 +522,107 @@ async def find_matching_grant(  # noqa: PLR0913
     return None, None, None
 
 
+async def visible_command_keys_for_context(  # noqa: PLR0913
+    *,
+    platform_id: str,
+    adapter_id: str,
+    implementation_name: str | None,
+    user_id: str | None,
+    resource_type: str | None,
+    resource_id: str | None,
+    native_roles: frozenset[str],
+    command_keys: Iterable[str],
+) -> frozenset[str]:
+    keys = list(dict.fromkeys(command_keys))
+    if not keys or user_id is None:
+        return frozenset()
+
+    now = utc_now()
+    async with get_session() as session:
+        node_stmt = (
+            select(PermissionNode)
+            .where(
+                PermissionNode.platform_id == platform_id,
+                PermissionNode.adapter_id == adapter_id,
+                PermissionNode.command_key.in_(keys),
+                PermissionNode.is_enabled.is_(True),
+                or_(
+                    PermissionNode.implementation_name.is_(None),
+                    PermissionNode.implementation_name == DEFAULT_IMPLEMENTATION,
+                    PermissionNode.implementation_name == implementation_name,
+                ),
+            )
+            .order_by(PermissionNode.id.desc())
+        )
+        command_nodes: dict[str, PermissionNode] = {}
+        for node in (await session.execute(node_stmt)).scalars():
+            if node.command_key is not None:
+                command_nodes.setdefault(node.command_key, node)
+        if not command_nodes:
+            return frozenset()
+
+        contract_stmt = select(CapabilityContract).where(
+            CapabilityContract.platform_id == platform_id,
+            CapabilityContract.adapter_id == adapter_id,
+            CapabilityContract.command_key.in_(command_nodes),
+        )
+        enabled_contract_keys = {
+            contract.command_key
+            for contract in (await session.execute(contract_stmt)).scalars()
+            if contract.is_enabled
+            and contract.implementation_name
+            in {DEFAULT_IMPLEMENTATION, implementation_name}
+        }
+        if not enabled_contract_keys:
+            return frozenset()
+
+        group_ids = await _matching_group_ids(
+            session=session,
+            platform_id=platform_id,
+            adapter_id=adapter_id,
+            user_id=user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            native_roles=native_roles,
+            now=now,
+        )
+        if not group_ids:
+            return frozenset()
+
+        grant_stmt = (
+            select(PermissionGroup, PermissionGrant, PermissionNode)
+            .join(PermissionGrant, PermissionGroup.id == PermissionGrant.group_id)
+            .join(PermissionNode, PermissionGrant.node_id == PermissionNode.id)
+            .where(
+                PermissionGroup.id.in_(group_ids),
+                PermissionGrant.is_enabled.is_(True),
+                PermissionNode.is_enabled.is_(True),
+                or_(
+                    PermissionGrant.resource_type == DEFAULT_VALUE,
+                    PermissionGrant.resource_type == resource_type,
+                ),
+                or_(
+                    PermissionGrant.resource_id == DEFAULT_VALUE,
+                    PermissionGrant.resource_id == resource_id,
+                ),
+                or_(
+                    PermissionGrant.expires_at.is_(None),
+                    PermissionGrant.expires_at > now,
+                ),
+            )
+            .order_by(PermissionGroup.priority.desc(), PermissionNode.path)
+        )
+        grant_nodes = [row[2] for row in (await session.execute(grant_stmt)).all()]
+
+    allowed: set[str] = set()
+    for command_key, target_node in command_nodes.items():
+        if command_key not in enabled_contract_keys:
+            continue
+        if any(_node_covers(grant_node, target_node) for grant_node in grant_nodes):
+            allowed.add(command_key)
+    return frozenset(allowed)
+
+
 async def capability_contract_allows(
     *,
     platform_id: str,
@@ -536,12 +640,83 @@ async def capability_contract_allows(
         limit=100,
     )
     if not contracts:
-        return True
+        return False
     return any(
         contract.is_enabled
         and contract.implementation_name
         in {DEFAULT_IMPLEMENTATION, implementation_name}
         for contract in contracts
+    )
+
+
+async def _matching_group_ids(  # noqa: PLR0913
+    *,
+    session: Any,
+    platform_id: str,
+    adapter_id: str,
+    user_id: str,
+    resource_type: str | None,
+    resource_id: str | None,
+    native_roles: frozenset[str],
+    now: datetime,
+) -> list[int]:
+    member_stmt = (
+        select(PermissionGroup, PermissionGroupMember)
+        .join(
+            PermissionGroupMember,
+            PermissionGroup.id == PermissionGroupMember.group_id,
+        )
+        .where(
+            PermissionGroup.is_enabled.is_(True),
+            PermissionGroupMember.platform_id == platform_id,
+            PermissionGroupMember.user_id == user_id,
+            or_(
+                PermissionGroupMember.resource_type == DEFAULT_VALUE,
+                PermissionGroupMember.resource_type == resource_type,
+            ),
+            or_(
+                PermissionGroupMember.resource_id == DEFAULT_VALUE,
+                PermissionGroupMember.resource_id == resource_id,
+            ),
+            or_(
+                PermissionGroupMember.expires_at.is_(None),
+                PermissionGroupMember.expires_at > now,
+            ),
+        )
+        .order_by(PermissionGroup.priority.desc())
+    )
+    groups: list[PermissionGroup] = [
+        row[0] for row in (await session.execute(member_stmt)).all()
+    ]
+
+    if native_roles:
+        native_stmt = (
+            select(PermissionGroup)
+            .join(
+                NativeRoleMapping,
+                PermissionGroup.id == NativeRoleMapping.group_id,
+            )
+            .where(
+                PermissionGroup.is_enabled.is_(True),
+                NativeRoleMapping.platform_id == platform_id,
+                or_(
+                    NativeRoleMapping.adapter_id == DEFAULT_VALUE,
+                    NativeRoleMapping.adapter_id == adapter_id,
+                ),
+                NativeRoleMapping.resource_type == (resource_type or "global"),
+                NativeRoleMapping.native_role.in_(native_roles),
+                NativeRoleMapping.is_enabled.is_(True),
+            )
+            .order_by(PermissionGroup.priority.desc())
+        )
+        groups.extend((await session.execute(native_stmt)).scalars())
+
+    return list(dict.fromkeys(group.id for group in groups))
+
+
+def _node_covers(grant_node: PermissionNode, target_node: PermissionNode) -> bool:
+    return target_node.path == grant_node.path or target_node.path.startswith(
+        f"{grant_node.path}/"
     )
 
 

--- a/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from asyncio import Lock
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +26,8 @@ SUPERUSER_RESULT = "superuser"
 ALLOW_RESULT = "allowed"
 DENY_RESULT = "denied"
 CAPABILITY_DENY_RESULT = "capability_denied"
+_default_state_ensured = False
+_default_state_lock = Lock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +96,17 @@ def permission_context_from_event(  # noqa: PLR0913
 
 
 async def ensure_default_permission_state() -> None:
+    global _default_state_ensured  # noqa: PLW0603
+    if _default_state_ensured:
+        return
+    async with _default_state_lock:
+        if _default_state_ensured:
+            return
+        await _sync_default_permission_state()
+        _default_state_ensured = True
+
+
+async def _sync_default_permission_state() -> None:
     root = await repository.upsert_node(
         path=ROOT_PATH,
         parent_id=None,

--- a/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
@@ -213,10 +213,19 @@ async def _sync_default_permission_state() -> None:
         )
 
 
-async def check_permission(context: PermissionContext) -> PermissionDecision:
+async def check_permission(
+    context: PermissionContext,
+    *,
+    audit: bool = True,
+) -> PermissionDecision:
     await ensure_default_permission_state()
     if is_superuser(context.user_id):
-        await audit_permission(context, result=SUPERUSER_RESULT, reason="superuser")
+        await _audit_permission_if_enabled(
+            enabled=audit,
+            context=context,
+            result=SUPERUSER_RESULT,
+            reason="superuser",
+        )
         return PermissionDecision(
             allowed=True,
             result=SUPERUSER_RESULT,
@@ -231,7 +240,12 @@ async def check_permission(context: PermissionContext) -> PermissionDecision:
     )
     if target_node is None:
         reason = "permission node not found"
-        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        await _audit_permission_if_enabled(
+            enabled=audit,
+            context=context,
+            result=DENY_RESULT,
+            reason=reason,
+        )
         return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
 
     if not await repository.capability_contract_allows(
@@ -241,8 +255,9 @@ async def check_permission(context: PermissionContext) -> PermissionDecision:
         command_key=context.command_key,
     ):
         reason = "capability contract disabled"
-        await audit_permission(
-            context,
+        await _audit_permission_if_enabled(
+            enabled=audit,
+            context=context,
             result=CAPABILITY_DENY_RESULT,
             reason=reason,
         )
@@ -254,7 +269,12 @@ async def check_permission(context: PermissionContext) -> PermissionDecision:
 
     if context.user_id is None:
         reason = "user id missing"
-        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        await _audit_permission_if_enabled(
+            enabled=audit,
+            context=context,
+            result=DENY_RESULT,
+            reason=reason,
+        )
         return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
 
     group, grant, grant_node = await repository.find_matching_grant(
@@ -267,11 +287,17 @@ async def check_permission(context: PermissionContext) -> PermissionDecision:
     )
     if group is None or grant is None or grant_node is None:
         reason = "no matching grant"
-        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        await _audit_permission_if_enabled(
+            enabled=audit,
+            context=context,
+            result=DENY_RESULT,
+            reason=reason,
+        )
         return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
 
-    await audit_permission(
-        context,
+    await _audit_permission_if_enabled(
+        enabled=audit,
+        context=context,
         result=ALLOW_RESULT,
         reason="matched grant",
         group_id=group.id,
@@ -318,6 +344,16 @@ async def audit_permission(  # noqa: PLR0913
         logger.exception("Failed to write permission audit log: %r", error)
 
 
+async def _audit_permission_if_enabled(
+    *,
+    enabled: bool,
+    context: PermissionContext,
+    **kwargs: Any,
+) -> None:
+    if enabled:
+        await audit_permission(context, **kwargs)
+
+
 async def visible_command_keys(context: PermissionContext) -> frozenset[str]:
     await ensure_default_permission_state()
     if is_superuser(context.user_id):
@@ -340,7 +376,7 @@ async def visible_command_keys(context: PermissionContext) -> frozenset[str]:
             resource_id=context.resource_id,
             native_roles=context.native_roles,
         )
-        decision = await check_permission(feature_context)
+        decision = await check_permission(feature_context, audit=False)
         if decision.allowed:
             allowed.add(feature.command_key)
     return frozenset(allowed)
@@ -391,12 +427,15 @@ async def add_group_member(
 
 async def list_tree_lines(limit: int = 80) -> list[str]:
     await ensure_default_permission_state()
-    nodes = await repository.list_permission_nodes(limit=limit)
-    return [
+    nodes = await repository.list_permission_nodes(limit=limit + 1)
+    lines = [
         f"{node.path} [{node.kind}]"
         + (f" -> {node.command_key}" if node.command_key else "")
-        for node in nodes
+        for node in nodes[:limit]
     ]
+    if len(nodes) > limit:
+        lines.append(f"... 已截断，使用 权限 tree <数量> 查看更多（当前 {limit} 条）")
+    return lines
 
 
 async def _ensure_child_node(  # noqa: PLR0913

--- a/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
@@ -95,12 +95,12 @@ def permission_context_from_event(  # noqa: PLR0913
     )
 
 
-async def ensure_default_permission_state() -> None:
+async def ensure_default_permission_state(*, force: bool = False) -> None:
     global _default_state_ensured  # noqa: PLW0603
-    if _default_state_ensured:
+    if _default_state_ensured and not force:
         return
     async with _default_state_lock:
-        if _default_state_ensured:
+        if _default_state_ensured and not force:
             return
         await _sync_default_permission_state()
         _default_state_ensured = True
@@ -363,23 +363,16 @@ async def visible_command_keys(context: PermissionContext) -> frozenset[str]:
 
     from ..handle import menu
 
-    allowed: set[str] = set()
-    for feature in menu.MENU_FEATURES:
-        feature_context = PermissionContext(
-            platform_id=context.platform_id,
-            adapter_id=context.adapter_id,
-            implementation_name=context.implementation_name,
-            command_key=feature.command_key,
-            user_id=context.user_id,
-            bot_id=context.bot_id,
-            resource_type=context.resource_type,
-            resource_id=context.resource_id,
-            native_roles=context.native_roles,
-        )
-        decision = await check_permission(feature_context, audit=False)
-        if decision.allowed:
-            allowed.add(feature.command_key)
-    return frozenset(allowed)
+    return await repository.visible_command_keys_for_context(
+        platform_id=context.platform_id,
+        adapter_id=context.adapter_id,
+        implementation_name=context.implementation_name,
+        user_id=context.user_id,
+        resource_type=context.resource_type,
+        resource_id=context.resource_id,
+        native_roles=context.native_roles,
+        command_keys=(feature.command_key for feature in menu.MENU_FEATURES),
+    )
 
 
 async def grant_group_to_node(

--- a/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/services/permissions.py
@@ -1,0 +1,496 @@
+"""Permission tree synchronization and authorization service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from nonebot import get_driver, logger
+
+from ..repositories import permissions as repository
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from nonebot.adapters import Bot, Event
+    from nonebot.internal.matcher.matcher import Matcher
+
+    from ..database.models import PermissionGrant, PermissionGroup, PermissionNode
+
+
+ROOT_PATH = "lingchu"
+GLOBAL_RESOURCE_TYPE = "global"
+GROUP_RESOURCE_TYPE = "group"
+SUPERUSER_RESULT = "superuser"
+ALLOW_RESULT = "allowed"
+DENY_RESULT = "denied"
+CAPABILITY_DENY_RESULT = "capability_denied"
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionContext:
+    platform_id: str
+    adapter_id: str
+    command_key: str
+    user_id: str | None = None
+    bot_id: str | None = None
+    resource_type: str | None = None
+    resource_id: str | None = None
+    implementation_name: str | None = None
+    native_roles: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionDecision:
+    allowed: bool
+    result: str
+    reason: str
+    group: PermissionGroup | None = None
+    grant: PermissionGrant | None = None
+    grant_node: PermissionNode | None = None
+
+
+def is_superuser(user_id: str | None) -> bool:
+    if user_id is None:
+        return False
+    try:
+        superusers = get_driver().config.superusers
+    except ValueError:
+        return False
+    return str(user_id) in {str(item) for item in superusers}
+
+
+def bind_command_key(command: type[Matcher], command_key: str) -> type[Matcher]:
+    setattr(command, "_lingchu_command_key", command_key)  # noqa: B010
+    return command
+
+
+def command_key_for(command: type[Matcher]) -> str | None:
+    value = getattr(command, "_lingchu_command_key", None)
+    return str(value) if value else None
+
+
+def permission_context_from_event(  # noqa: PLR0913
+    *,
+    bot: Bot,
+    event: Event,
+    adapter_id: str,
+    command_key: str,
+    platform_id: str = "qq",
+    implementation_name: str | None = None,
+) -> PermissionContext:
+    return PermissionContext(
+        platform_id=platform_id,
+        adapter_id=adapter_id,
+        command_key=command_key,
+        user_id=_event_user_id(event),
+        bot_id=_bot_id(bot),
+        resource_type=_event_resource_type(event),
+        resource_id=_event_resource_id(event),
+        implementation_name=implementation_name,
+        native_roles=_event_native_roles(event),
+    )
+
+
+async def ensure_default_permission_state() -> None:
+    root = await repository.upsert_node(
+        path=ROOT_PATH,
+        parent_id=None,
+        kind="root",
+        title="Lingchu",
+    )
+    owner_group = await repository.upsert_group(
+        key=repository.DEFAULT_OWNER_GROUP_KEY,
+        name="Native Owner",
+        priority=900,
+        is_builtin=True,
+    )
+    admin_group = await repository.upsert_group(
+        key=repository.DEFAULT_ADMIN_GROUP_KEY,
+        name="Native Admin",
+        priority=800,
+        is_builtin=True,
+    )
+
+    from ..handle import menu
+
+    command_paths: dict[tuple[str, str, str | None, str], PermissionNode] = {}
+    for feature in menu.MENU_FEATURES:
+        for availability in feature.availability:
+            platform = await _ensure_child_node(
+                root,
+                f"platform:{availability.platform_id}",
+                kind="platform",
+                title=availability.platform_id,
+                platform_id=availability.platform_id,
+            )
+            adapter = await _ensure_child_node(
+                platform,
+                f"adapter:{availability.adapter_id}",
+                kind="adapter",
+                title=availability.adapter_id,
+                platform_id=availability.platform_id,
+                adapter_id=availability.adapter_id,
+            )
+            implementation_value = availability.implementation_name or "default"
+            implementation = await _ensure_child_node(
+                adapter,
+                f"implementation:{implementation_value}",
+                kind="implementation",
+                title=implementation_value,
+                platform_id=availability.platform_id,
+                adapter_id=availability.adapter_id,
+                implementation_name=implementation_value,
+            )
+            section_parent = await _ensure_menu_section_path(
+                implementation,
+                feature.section_id,
+                platform_id=availability.platform_id,
+                adapter_id=availability.adapter_id,
+                implementation_name=implementation_value,
+            )
+            command_node = await _ensure_child_node(
+                section_parent,
+                f"command:{feature.command_key}",
+                kind="command",
+                title=feature.id,
+                platform_id=availability.platform_id,
+                adapter_id=availability.adapter_id,
+                implementation_name=implementation_value,
+                command_key=feature.command_key,
+            )
+            command_paths[
+                (
+                    availability.platform_id,
+                    availability.adapter_id,
+                    availability.implementation_name,
+                    feature.command_key,
+                )
+            ] = command_node
+            await repository.upsert_capability_contract(
+                platform_id=availability.platform_id,
+                adapter_id=availability.adapter_id,
+                implementation_name=availability.implementation_name,
+                command_key=feature.command_key,
+                capability=str(feature.platform_capability),
+                minimum_version=availability.minimum_version,
+                protocol_version=availability.protocol_version,
+            )
+
+    for group in (owner_group, admin_group):
+        for platform_id in sorted({item[0] for item in command_paths}):
+            platform_node = await repository.get_node_by_path(
+                f"{ROOT_PATH}/platform:{platform_id}"
+            )
+            if platform_node is not None:
+                await repository.upsert_grant(
+                    group_id=group.id,
+                    node_id=platform_node.id,
+                    resource_type=GROUP_RESOURCE_TYPE,
+                )
+
+    for native_role, group in (("owner", owner_group), ("admin", admin_group)):
+        await repository.upsert_native_role_mapping(
+            platform_id="qq",
+            adapter_id=None,
+            resource_type=GROUP_RESOURCE_TYPE,
+            native_role=native_role,
+            group_id=group.id,
+        )
+
+
+async def check_permission(context: PermissionContext) -> PermissionDecision:
+    await ensure_default_permission_state()
+    if is_superuser(context.user_id):
+        await audit_permission(context, result=SUPERUSER_RESULT, reason="superuser")
+        return PermissionDecision(
+            allowed=True,
+            result=SUPERUSER_RESULT,
+            reason="superuser",
+        )
+
+    target_node = await repository.get_command_node(
+        platform_id=context.platform_id,
+        adapter_id=context.adapter_id,
+        implementation_name=context.implementation_name,
+        command_key=context.command_key,
+    )
+    if target_node is None:
+        reason = "permission node not found"
+        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
+
+    if not await repository.capability_contract_allows(
+        platform_id=context.platform_id,
+        adapter_id=context.adapter_id,
+        implementation_name=context.implementation_name,
+        command_key=context.command_key,
+    ):
+        reason = "capability contract disabled"
+        await audit_permission(
+            context,
+            result=CAPABILITY_DENY_RESULT,
+            reason=reason,
+        )
+        return PermissionDecision(
+            allowed=False,
+            result=CAPABILITY_DENY_RESULT,
+            reason=reason,
+        )
+
+    if context.user_id is None:
+        reason = "user id missing"
+        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
+
+    group, grant, grant_node = await repository.find_matching_grant(
+        platform_id=context.platform_id,
+        user_id=context.user_id,
+        target_node=target_node,
+        resource_type=context.resource_type,
+        resource_id=context.resource_id,
+        native_roles=context.native_roles,
+    )
+    if group is None or grant is None or grant_node is None:
+        reason = "no matching grant"
+        await audit_permission(context, result=DENY_RESULT, reason=reason)
+        return PermissionDecision(allowed=False, result=DENY_RESULT, reason=reason)
+
+    await audit_permission(
+        context,
+        result=ALLOW_RESULT,
+        reason="matched grant",
+        group_id=group.id,
+        grant_node_id=grant_node.id,
+    )
+    return PermissionDecision(
+        allowed=True,
+        result=ALLOW_RESULT,
+        reason="matched grant",
+        group=group,
+        grant=grant,
+        grant_node=grant_node,
+    )
+
+
+async def audit_permission(  # noqa: PLR0913
+    context: PermissionContext,
+    *,
+    result: str,
+    reason: str | None = None,
+    action: str = "check_permission",
+    group_id: int | None = None,
+    grant_node_id: int | None = None,
+    exception_summary: str | None = None,
+) -> None:
+    try:
+        await repository.create_audit_log(
+            platform_id=context.platform_id,
+            adapter_id=context.adapter_id,
+            implementation_name=context.implementation_name,
+            bot_id=context.bot_id,
+            user_id=context.user_id,
+            resource_type=context.resource_type,
+            resource_id=context.resource_id,
+            command_key=context.command_key,
+            action=action,
+            result=result,
+            group_id=group_id,
+            grant_node_id=grant_node_id,
+            reason=reason,
+            exception_summary=exception_summary,
+        )
+    except Exception as error:  # noqa: BLE001
+        logger.exception("Failed to write permission audit log: %r", error)
+
+
+async def visible_command_keys(context: PermissionContext) -> frozenset[str]:
+    await ensure_default_permission_state()
+    if is_superuser(context.user_id):
+        from ..handle.qq.group.command_triggers import COMMAND_TRIGGERS
+
+        return frozenset(COMMAND_TRIGGERS)
+
+    from ..handle import menu
+
+    allowed: set[str] = set()
+    for feature in menu.MENU_FEATURES:
+        feature_context = PermissionContext(
+            platform_id=context.platform_id,
+            adapter_id=context.adapter_id,
+            implementation_name=context.implementation_name,
+            command_key=feature.command_key,
+            user_id=context.user_id,
+            bot_id=context.bot_id,
+            resource_type=context.resource_type,
+            resource_id=context.resource_id,
+            native_roles=context.native_roles,
+        )
+        decision = await check_permission(feature_context)
+        if decision.allowed:
+            allowed.add(feature.command_key)
+    return frozenset(allowed)
+
+
+async def grant_group_to_node(
+    *,
+    group_key: str,
+    node_path: str,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+) -> bool:
+    await ensure_default_permission_state()
+    group = await repository.get_group_by_key(group_key)
+    node = await repository.get_node_by_path(node_path)
+    if group is None or node is None:
+        return False
+    await repository.upsert_grant(
+        group_id=group.id,
+        node_id=node.id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+    return True
+
+
+async def add_group_member(
+    *,
+    group_key: str,
+    platform_id: str,
+    user_id: str,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+) -> bool:
+    await ensure_default_permission_state()
+    group = await repository.get_group_by_key(group_key)
+    if group is None:
+        return False
+    await repository.upsert_member(
+        group_id=group.id,
+        platform_id=platform_id,
+        user_id=user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+    return True
+
+
+async def list_tree_lines(limit: int = 80) -> list[str]:
+    await ensure_default_permission_state()
+    nodes = await repository.list_permission_nodes(limit=limit)
+    return [
+        f"{node.path} [{node.kind}]"
+        + (f" -> {node.command_key}" if node.command_key else "")
+        for node in nodes
+    ]
+
+
+async def _ensure_child_node(  # noqa: PLR0913
+    parent: PermissionNode,
+    segment: str,
+    *,
+    kind: str,
+    title: str | None = None,
+    platform_id: str | None = None,
+    adapter_id: str | None = None,
+    implementation_name: str | None = None,
+    command_key: str | None = None,
+) -> PermissionNode:
+    return await repository.upsert_node(
+        path=f"{parent.path}/{segment}",
+        parent_id=parent.id,
+        kind=kind,
+        title=title,
+        platform_id=platform_id,
+        adapter_id=adapter_id,
+        implementation_name=implementation_name,
+        command_key=command_key,
+    )
+
+
+async def _ensure_menu_section_path(
+    implementation: PermissionNode,
+    section_id: str,
+    *,
+    platform_id: str,
+    adapter_id: str,
+    implementation_name: str,
+) -> PermissionNode:
+    from ..handle import menu
+
+    page_chain = _page_chain(menu.MENU_PAGES, section_id)
+    parent = implementation
+    if not page_chain:
+        return await _ensure_child_node(
+            parent,
+            f"section:{section_id}",
+            kind="section",
+            title=section_id,
+            platform_id=platform_id,
+            adapter_id=adapter_id,
+            implementation_name=implementation_name,
+        )
+    for page in page_chain:
+        parent = await _ensure_child_node(
+            parent,
+            f"section:{page.id}",
+            kind="section",
+            title=page.id,
+            platform_id=platform_id,
+            adapter_id=adapter_id,
+            implementation_name=implementation_name,
+        )
+    return parent
+
+
+def _page_chain(pages: Iterable[Any], target_id: str) -> tuple[Any, ...]:
+    for page in pages:
+        if page.id == target_id:
+            return (page,)
+        child_chain = _page_chain(page.children, target_id)
+        if child_chain:
+            return (page, *child_chain)
+    return ()
+
+
+def _bot_id(bot: Bot) -> str | None:
+    value = getattr(bot, "self_id", None)
+    return None if value is None else str(value)
+
+
+def _event_user_id(event: Event) -> str | None:
+    try:
+        return str(event.get_user_id())
+    except Exception:  # noqa: BLE001
+        value = getattr(event, "user_id", None)
+        return None if value is None else str(value)
+
+
+def _event_resource_type(event: Event) -> str | None:
+    if _event_resource_id(event) is None:
+        return None
+    return GROUP_RESOURCE_TYPE
+
+
+def _event_resource_id(event: Event) -> str | None:
+    for attr in ("group_id", "guild_id", "channel_id"):
+        value = getattr(event, attr, None)
+        if value is not None:
+            return str(value)
+    data = getattr(event, "data", None)
+    peer_id = getattr(data, "peer_id", None)
+    return None if peer_id is None else str(peer_id)
+
+
+def _event_native_roles(event: Event) -> frozenset[str]:
+    sender = getattr(event, "sender", None)
+    role = getattr(sender, "role", None)
+    if role is None:
+        data = getattr(event, "data", None)
+        role = getattr(data, "sender_role", None)
+    normalized = str(role).casefold() if role is not None else ""
+    if normalized in {"owner", "admin", "administrator"}:
+        return frozenset({"admin" if normalized == "administrator" else normalized})
+    if normalized in {"member", ""}:
+        return frozenset()
+    return frozenset({normalized})

--- a/src/plugins/nonebot_plugin_lingchu_bot/start/startup.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/start/startup.py
@@ -17,6 +17,7 @@ from ..services.messagestore import (
     record_bot_lifecycle,
     shutdown_message_store,
 )
+from ..services.permissions import ensure_default_permission_state
 
 
 async def startup() -> None:
@@ -45,6 +46,7 @@ async def startup() -> None:
             )
         )
     await warm_translation_cache()
+    await ensure_default_permission_state()
     await group_import_handle()
     await menu_import_handle()
     await initialize_message_store()

--- a/tests/handle/commands/group/test_command_triggers.py
+++ b/tests/handle/commands/group/test_command_triggers.py
@@ -23,6 +23,12 @@ EXPECTED_TRIGGERS: dict[str, ExpectedTrigger] = {
         "chinese_aliases": {"帮助", "功能", "功能列表", "指令", "命令列表"},
         "english_aliases": {"help", "commands"},
     },
+    "permission": {
+        "primary": "权限",
+        "english": "permission",
+        "chinese_aliases": {"权限管理", "授权"},
+        "english_aliases": {"perm", "permissions"},
+    },
     "member_mute": {
         "primary": "禁言",
         "english": "mute",

--- a/tests/handle/commands/group/test_menu.py
+++ b/tests/handle/commands/group/test_menu.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -254,6 +254,26 @@ def test_milky_unknown_hides_announcement() -> None:
 
     assert "发送群公告" not in rendered
     assert "设置群头像" in rendered
+
+
+def test_onebot_menu_native_roles_are_normalized() -> None:
+    event = SimpleNamespace(sender=SimpleNamespace(role="administrator"))
+
+    assert onebot_menu_module._event_native_roles(cast("Any", event)) == frozenset(
+        {"admin"}
+    )
+    assert onebot_menu_module._normalize_native_role("member") == frozenset()
+    assert onebot_menu_module._normalize_native_role(None) == frozenset()
+
+
+def test_milky_menu_native_roles_are_normalized() -> None:
+    event = SimpleNamespace(data=SimpleNamespace(sender_role="administrator"))
+
+    assert milky_menu_module._event_native_roles(cast("Any", event)) == frozenset(
+        {"admin"}
+    )
+    assert milky_menu_module._normalize_native_role("member") == frozenset()
+    assert milky_menu_module._normalize_native_role(None) == frozenset()
 
 
 def test_fail_closed_when_platform_capability_missing() -> None:

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.plugins.nonebot_plugin_lingchu_bot.services import permissions
+
+
+@pytest.mark.asyncio
+async def test_default_permission_state_syncs_menu_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes: dict[str, SimpleNamespace] = {}
+    grants: list[dict[str, object]] = []
+
+    async def upsert_node(**fields: object) -> SimpleNamespace:
+        node = SimpleNamespace(id=len(nodes) + 1, **fields)
+        nodes[str(fields["path"])] = node
+        return node
+
+    async def get_node_by_path(path: str) -> SimpleNamespace | None:
+        return nodes.get(path)
+
+    async def upsert_group(**fields: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=1 if fields["key"] == "native-owner" else 2,
+            **fields,
+        )
+
+    async def upsert_grant(**fields: object) -> SimpleNamespace:
+        grants.append(fields)
+        return SimpleNamespace(id=len(grants), **fields)
+
+    monkeypatch.setattr(permissions.repository, "upsert_node", upsert_node)
+    monkeypatch.setattr(permissions.repository, "get_node_by_path", get_node_by_path)
+    monkeypatch.setattr(permissions.repository, "upsert_group", upsert_group)
+    monkeypatch.setattr(permissions.repository, "upsert_grant", upsert_grant)
+    monkeypatch.setattr(
+        permissions.repository,
+        "upsert_capability_contract",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        permissions.repository,
+        "upsert_native_role_mapping",
+        AsyncMock(),
+    )
+
+    await permissions.ensure_default_permission_state()
+
+    assert "lingchu/platform:qq" in nodes
+    assert "lingchu/platform:qq/adapter:~onebot.v11" in nodes
+    assert any(path.endswith("/command:kick_member") for path in nodes)
+    assert any(grant["resource_type"] == "group" for grant in grants)
+
+
+@pytest.mark.asyncio
+async def test_check_permission_allows_superuser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    monkeypatch.setattr(
+        permissions,
+        "get_driver",
+        lambda: SimpleNamespace(config=SimpleNamespace(superusers={"42"})),
+    )
+    audit = AsyncMock()
+    monkeypatch.setattr(permissions, "audit_permission", audit)
+
+    decision = await permissions.check_permission(
+        permissions.PermissionContext(
+            platform_id="qq",
+            adapter_id="~onebot.v11",
+            command_key="kick_member",
+            user_id="42",
+        )
+    )
+
+    assert decision.allowed is True
+    assert decision.result == permissions.SUPERUSER_RESULT
+    audit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_permission_allows_matching_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = SimpleNamespace(
+        id=10,
+        path="lingchu/platform:qq/adapter:~onebot.v11/command:kick_member",
+        adapter_id="~onebot.v11",
+    )
+    group = SimpleNamespace(id=20)
+    grant = SimpleNamespace(id=30)
+    grant_node = SimpleNamespace(id=40, path="lingchu/platform:qq")
+
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    monkeypatch.setattr(
+        permissions,
+        "get_driver",
+        lambda: SimpleNamespace(config=SimpleNamespace(superusers=set())),
+    )
+    monkeypatch.setattr(permissions, "audit_permission", AsyncMock())
+    monkeypatch.setattr(
+        permissions.repository,
+        "get_command_node",
+        AsyncMock(return_value=target),
+    )
+    monkeypatch.setattr(
+        permissions.repository,
+        "capability_contract_allows",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        permissions.repository,
+        "find_matching_grant",
+        AsyncMock(return_value=(group, grant, grant_node)),
+    )
+
+    decision = await permissions.check_permission(
+        permissions.PermissionContext(
+            platform_id="qq",
+            adapter_id="~onebot.v11",
+            command_key="kick_member",
+            user_id="100",
+            resource_type="group",
+            resource_id="200",
+        )
+    )
+
+    assert decision.allowed is True
+    assert decision.group is group
+    assert decision.grant_node is grant_node
+
+
+@pytest.mark.asyncio
+async def test_check_permission_denies_disabled_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    monkeypatch.setattr(
+        permissions,
+        "get_driver",
+        lambda: SimpleNamespace(config=SimpleNamespace(superusers=set())),
+    )
+    monkeypatch.setattr(permissions, "audit_permission", AsyncMock())
+    monkeypatch.setattr(
+        permissions.repository,
+        "get_command_node",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=1,
+                path="lingchu/platform:qq",
+                adapter_id="~onebot.v11",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        permissions.repository,
+        "capability_contract_allows",
+        AsyncMock(return_value=False),
+    )
+
+    decision = await permissions.check_permission(
+        permissions.PermissionContext(
+            platform_id="qq",
+            adapter_id="~onebot.v11",
+            command_key="kick_member",
+            user_id="100",
+        )
+    )
+
+    assert decision.allowed is False
+    assert decision.result == permissions.CAPABILITY_DENY_RESULT

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -375,7 +375,7 @@ async def test_permission_native_mapping_validates_role(
 async def test_permission_native_mapping_normalizes_role(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    set_native_role_mapping_enabled = AsyncMock()
+    set_native_role_mapping_enabled = AsyncMock(return_value=(1, True))
     finish = AsyncMock()
     monkeypatch.setattr(permission_module, "is_superuser", lambda _user_id: True)
     monkeypatch.setattr(
@@ -404,6 +404,36 @@ async def test_permission_native_mapping_normalizes_role(
         is_enabled=False,
     )
     finish.assert_awaited_once_with(message="原生身份映射已禁用: owner")
+
+
+@pytest.mark.asyncio
+async def test_permission_native_mapping_reports_missing_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_native_role_mapping_enabled = AsyncMock(return_value=(0, False))
+    finish = AsyncMock()
+    monkeypatch.setattr(permission_module, "is_superuser", lambda _user_id: True)
+    monkeypatch.setattr(
+        permission_module.repository,
+        "set_native_role_mapping_enabled",
+        set_native_role_mapping_enabled,
+    )
+    monkeypatch.setattr(permission_module.permission_cmd, "finish", finish)
+
+    await permission_module._handle_permission(
+        cast("Any", SimpleNamespace()),
+        cast("Any", SimpleNamespace(get_user_id=lambda: "42")),
+        "native-on",
+        "admin",
+        "",
+        "",
+        "",
+        "",
+    )
+
+    finish.assert_awaited_once_with(
+        message="原生身份映射未找到，请先执行 权限 sync: admin"
+    )
 
 
 @pytest.mark.asyncio
@@ -567,6 +597,81 @@ async def test_visible_command_keys_for_context_uses_bulk_queries(
 
     assert visible == {"kick_member"}
     assert len(statements) == expected_query_count
+
+
+@pytest.mark.asyncio
+async def test_visible_command_keys_prefers_specific_implementation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_node = SimpleNamespace(
+        id=11,
+        command_key="kick_member",
+        implementation_name=repository.DEFAULT_IMPLEMENTATION,
+        path="lingchu/platform:qq/adapter:~onebot.v11/implementation:default/command:kick_member",
+    )
+    specific_node = SimpleNamespace(
+        id=10,
+        command_key="kick_member",
+        implementation_name="napcat",
+        path="lingchu/platform:qq/adapter:~onebot.v11/implementation:napcat/command:kick_member",
+    )
+    contract = SimpleNamespace(
+        command_key="kick_member",
+        implementation_name="napcat",
+        is_enabled=True,
+    )
+    group = SimpleNamespace(id=20, priority=100)
+    grant_node = SimpleNamespace(
+        id=30,
+        path="lingchu/platform:qq/adapter:~onebot.v11/implementation:napcat",
+    )
+    responses: list[list[object]] = [
+        [default_node, specific_node],
+        [contract],
+        [(group, SimpleNamespace())],
+        [(group, SimpleNamespace(), grant_node)],
+    ]
+
+    class Result:
+        def __init__(self, rows: list[object]) -> None:
+            self._rows = rows
+
+        def all(self) -> list[object]:
+            return self._rows
+
+        def scalars(self) -> list[object]:
+            return self._rows
+
+    class FakeSession:
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def execute(self, _statement: object) -> Result:
+            if responses:
+                return Result(responses.pop(0))
+            msg = "visible_command_keys_for_context should use fixed bulk queries"
+            raise AssertionError(msg)
+
+    def get_fake_session() -> FakeSession:
+        return FakeSession()
+
+    monkeypatch.setattr(repository, "get_session", get_fake_session)
+
+    visible = await repository.visible_command_keys_for_context(
+        platform_id="qq",
+        adapter_id="~onebot.v11",
+        implementation_name="napcat",
+        user_id="100",
+        resource_type="group",
+        resource_id="200",
+        native_roles=frozenset(),
+        command_keys=["kick_member"],
+    )
+
+    assert visible == {"kick_member"}
 
 
 def test_permission_models_have_cascade_foreign_keys() -> None:

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -12,6 +12,12 @@ from src.plugins.nonebot_plugin_lingchu_bot.database.models import (
     PermissionNode,
 )
 from src.plugins.nonebot_plugin_lingchu_bot.handle.qq.group import common
+from src.plugins.nonebot_plugin_lingchu_bot.handle.qq.group import (
+    permission as permission_module,
+)
+from src.plugins.nonebot_plugin_lingchu_bot.handle.qq.group.command_triggers import (
+    COMMAND_TRIGGERS,
+)
 from src.plugins.nonebot_plugin_lingchu_bot.repositories import (
     permissions as repository,
 )
@@ -235,6 +241,100 @@ async def test_check_permission_denies_disabled_capability(
 
     assert decision.allowed is False
     assert decision.result == permissions.CAPABILITY_DENY_RESULT
+
+
+@pytest.mark.asyncio
+async def test_visible_command_keys_filters_without_audit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, bool]] = []
+
+    async def fake_check_permission(
+        context: permissions.PermissionContext,
+        *,
+        audit: bool = True,
+    ) -> permissions.PermissionDecision:
+        seen.append((context.command_key, audit))
+        return permissions.PermissionDecision(
+            allowed=context.command_key == "kick_member",
+            result=permissions.ALLOW_RESULT,
+            reason="test",
+        )
+
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    monkeypatch.setattr(permissions, "is_superuser", lambda _user_id: False)
+    monkeypatch.setattr(permissions, "check_permission", fake_check_permission)
+
+    visible = await permissions.visible_command_keys(
+        permissions.PermissionContext(
+            platform_id="qq",
+            adapter_id="~onebot.v11",
+            command_key="menu",
+            user_id="100",
+        )
+    )
+
+    assert visible == {"kick_member"}
+    assert seen
+    assert all(audit is False for _, audit in seen)
+
+
+@pytest.mark.asyncio
+async def test_visible_command_keys_superuser_sees_all_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    monkeypatch.setattr(permissions, "is_superuser", lambda _user_id: True)
+    check_permission = AsyncMock()
+    monkeypatch.setattr(permissions, "check_permission", check_permission)
+
+    visible = await permissions.visible_command_keys(
+        permissions.PermissionContext(
+            platform_id="qq",
+            adapter_id="~onebot.v11",
+            command_key="menu",
+            user_id="42",
+        )
+    )
+
+    assert visible == set(COMMAND_TRIGGERS)
+    check_permission.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_tree_lines_adds_truncation_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
+    nodes = [
+        SimpleNamespace(path=f"lingchu/{index}", kind="section", command_key=None)
+        for index in range(3)
+    ]
+    list_permission_nodes = AsyncMock(return_value=nodes)
+    monkeypatch.setattr(
+        permissions.repository,
+        "list_permission_nodes",
+        list_permission_nodes,
+    )
+
+    lines = await permissions.list_tree_lines(limit=2)
+
+    list_permission_nodes.assert_awaited_once_with(limit=3)
+    assert lines == [
+        "lingchu/0 [section]",
+        "lingchu/1 [section]",
+        "... 已截断，使用 权限 tree <数量> 查看更多（当前 2 条）",
+    ]
+
+
+def test_permission_tree_limit_parser() -> None:
+    custom_limit = 200
+
+    assert permission_module._parse_positive_limit("") is None
+    assert permission_module._parse_positive_limit(str(custom_limit)) == custom_limit
+    assert permission_module._parse_positive_limit("0") is None
+    assert permission_module._parse_positive_limit("-1") is None
+    assert permission_module._parse_positive_limit("bad") is None
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Self, cast
+from typing import Any, Self, cast
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.plugins.nonebot_plugin_lingchu_bot.database.models import (
+    NativeRoleMapping,
     PermissionGrant,
     PermissionGroupMember,
     PermissionNode,
@@ -53,15 +54,17 @@ async def test_default_permission_state_syncs_menu_tree(
     monkeypatch.setattr(permissions.repository, "get_node_by_path", get_node_by_path)
     monkeypatch.setattr(permissions.repository, "upsert_group", upsert_group)
     monkeypatch.setattr(permissions.repository, "upsert_grant", upsert_grant)
+    upsert_capability_contract = AsyncMock()
+    upsert_native_role_mapping = AsyncMock()
     monkeypatch.setattr(
         permissions.repository,
         "upsert_capability_contract",
-        AsyncMock(),
+        upsert_capability_contract,
     )
     monkeypatch.setattr(
         permissions.repository,
         "upsert_native_role_mapping",
-        AsyncMock(),
+        upsert_native_role_mapping,
     )
     monkeypatch.setattr(permissions, "_default_state_ensured", False)
 
@@ -71,6 +74,8 @@ async def test_default_permission_state_syncs_menu_tree(
     assert "lingchu/platform:qq/adapter:~onebot.v11" in nodes
     assert any(path.endswith("/command:kick_member") for path in nodes)
     assert any(grant["resource_type"] == "group" for grant in grants)
+    upsert_capability_contract.assert_awaited()
+    upsert_native_role_mapping.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -121,6 +126,11 @@ async def test_default_permission_state_is_cached_after_success(
     upsert_capability_contract.assert_awaited()
     upsert_native_role_mapping.assert_awaited()
     assert upsert_paths.count("lingchu") == 1
+
+    await permissions.ensure_default_permission_state(force=True)
+
+    expected_forced_sync_count = 2
+    assert upsert_paths.count("lingchu") == expected_forced_sync_count
 
 
 @pytest.mark.asyncio
@@ -247,23 +257,18 @@ async def test_check_permission_denies_disabled_capability(
 async def test_visible_command_keys_filters_without_audit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    seen: list[tuple[str, bool]] = []
-
-    async def fake_check_permission(
-        context: permissions.PermissionContext,
-        *,
-        audit: bool = True,
-    ) -> permissions.PermissionDecision:
-        seen.append((context.command_key, audit))
-        return permissions.PermissionDecision(
-            allowed=context.command_key == "kick_member",
-            result=permissions.ALLOW_RESULT,
-            reason="test",
-        )
-
     monkeypatch.setattr(permissions, "ensure_default_permission_state", AsyncMock())
     monkeypatch.setattr(permissions, "is_superuser", lambda _user_id: False)
-    monkeypatch.setattr(permissions, "check_permission", fake_check_permission)
+    visible_command_keys_for_context = AsyncMock(
+        return_value=frozenset({"kick_member"})
+    )
+    check_permission = AsyncMock()
+    monkeypatch.setattr(
+        permissions.repository,
+        "visible_command_keys_for_context",
+        visible_command_keys_for_context,
+    )
+    monkeypatch.setattr(permissions, "check_permission", check_permission)
 
     visible = await permissions.visible_command_keys(
         permissions.PermissionContext(
@@ -275,8 +280,8 @@ async def test_visible_command_keys_filters_without_audit(
     )
 
     assert visible == {"kick_member"}
-    assert seen
-    assert all(audit is False for _, audit in seen)
+    visible_command_keys_for_context.assert_awaited_once()
+    check_permission.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -335,6 +340,70 @@ def test_permission_tree_limit_parser() -> None:
     assert permission_module._parse_positive_limit("0") is None
     assert permission_module._parse_positive_limit("-1") is None
     assert permission_module._parse_positive_limit("bad") is None
+
+
+@pytest.mark.asyncio
+async def test_permission_native_mapping_validates_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_native_role_mapping_enabled = AsyncMock()
+    finish = AsyncMock()
+    monkeypatch.setattr(permission_module, "is_superuser", lambda _user_id: True)
+    monkeypatch.setattr(
+        permission_module.repository,
+        "set_native_role_mapping_enabled",
+        set_native_role_mapping_enabled,
+    )
+    monkeypatch.setattr(permission_module.permission_cmd, "finish", finish)
+
+    await permission_module._handle_permission(
+        cast("Any", SimpleNamespace()),
+        cast("Any", SimpleNamespace(get_user_id=lambda: "42")),
+        "native-on",
+        "invalid",
+        "",
+        "",
+        "",
+        "",
+    )
+
+    finish.assert_awaited_once_with(message="无效的角色: 仅支持 owner 或 admin")
+    set_native_role_mapping_enabled.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_permission_native_mapping_normalizes_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_native_role_mapping_enabled = AsyncMock()
+    finish = AsyncMock()
+    monkeypatch.setattr(permission_module, "is_superuser", lambda _user_id: True)
+    monkeypatch.setattr(
+        permission_module.repository,
+        "set_native_role_mapping_enabled",
+        set_native_role_mapping_enabled,
+    )
+    monkeypatch.setattr(permission_module.permission_cmd, "finish", finish)
+
+    await permission_module._handle_permission(
+        cast("Any", SimpleNamespace()),
+        cast("Any", SimpleNamespace(get_user_id=lambda: "42")),
+        "native-off",
+        "OWNER",
+        "",
+        "",
+        "",
+        "",
+    )
+
+    set_native_role_mapping_enabled.assert_awaited_once_with(
+        platform_id="qq",
+        adapter_id=None,
+        resource_type="group",
+        native_role="owner",
+        is_enabled=False,
+    )
+    finish.assert_awaited_once_with(message="原生身份映射已禁用: owner")
 
 
 @pytest.mark.asyncio
@@ -425,12 +494,88 @@ async def test_find_matching_grant_uses_global_group_priority(  # noqa: C901
     assert len(statements) == grant_query_count
 
 
+@pytest.mark.asyncio
+async def test_visible_command_keys_for_context_uses_bulk_queries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_node = SimpleNamespace(
+        id=10,
+        command_key="kick_member",
+        path="lingchu/platform:qq/adapter:~onebot.v11/command:kick_member",
+    )
+    missing_contract_node = SimpleNamespace(
+        id=9,
+        command_key="leave_group",
+        path="lingchu/platform:qq/adapter:~onebot.v11/command:leave_group",
+    )
+    contract = SimpleNamespace(
+        command_key="kick_member",
+        implementation_name=repository.DEFAULT_IMPLEMENTATION,
+        is_enabled=True,
+    )
+    group = SimpleNamespace(id=20, priority=100)
+    grant_node = SimpleNamespace(id=30, path="lingchu/platform:qq")
+    statements: list[object] = []
+    expected_query_count = 4
+    responses: list[list[object]] = [
+        [target_node, missing_contract_node],
+        [contract],
+        [(group, SimpleNamespace())],
+        [(group, SimpleNamespace(), grant_node)],
+    ]
+
+    class Result:
+        def __init__(self, rows: list[object]) -> None:
+            self._rows = rows
+
+        def all(self) -> list[object]:
+            return self._rows
+
+        def scalars(self) -> list[object]:
+            return self._rows
+
+    class FakeSession:
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def execute(self, statement: object) -> Result:
+            statements.append(statement)
+            response_index = len(statements) - 1
+            if response_index < len(responses):
+                return Result(responses[response_index])
+            msg = "visible_command_keys_for_context should use fixed bulk queries"
+            raise AssertionError(msg)
+
+    def get_fake_session() -> FakeSession:
+        return FakeSession()
+
+    monkeypatch.setattr(repository, "get_session", get_fake_session)
+
+    visible = await repository.visible_command_keys_for_context(
+        platform_id="qq",
+        adapter_id="~onebot.v11",
+        implementation_name=None,
+        user_id="100",
+        resource_type="group",
+        resource_id="200",
+        native_roles=frozenset(),
+        command_keys=["kick_member", "leave_group"],
+    )
+
+    assert visible == {"kick_member"}
+    assert len(statements) == expected_query_count
+
+
 def test_permission_models_have_cascade_foreign_keys() -> None:
     member_group_fk = next(
         iter(PermissionGroupMember.__table__.c.group_id.foreign_keys)
     )
     grant_group_fk = next(iter(PermissionGrant.__table__.c.group_id.foreign_keys))
     grant_node_fk = next(iter(PermissionGrant.__table__.c.node_id.foreign_keys))
+    native_group_fk = next(iter(NativeRoleMapping.__table__.c.group_id.foreign_keys))
 
     assert member_group_fk.target_fullname == "lingchu_permission_groups.id"
     assert member_group_fk.ondelete == "CASCADE"
@@ -438,3 +583,5 @@ def test_permission_models_have_cascade_foreign_keys() -> None:
     assert grant_group_fk.ondelete == "CASCADE"
     assert grant_node_fk.target_fullname == "lingchu_permission_nodes.id"
     assert grant_node_fk.ondelete == "CASCADE"
+    assert native_group_fk.target_fullname == "lingchu_permission_groups.id"
+    assert native_group_fk.ondelete == "CASCADE"

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -254,6 +254,38 @@ async def test_check_permission_denies_disabled_capability(
 
 
 @pytest.mark.asyncio
+async def test_get_command_node_prefers_specific_implementation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_limit = 100
+    default_node = SimpleNamespace(
+        id=11,
+        command_key="kick_member",
+        implementation_name=repository.DEFAULT_IMPLEMENTATION,
+    )
+    specific_node = SimpleNamespace(
+        id=10,
+        command_key="kick_member",
+        implementation_name="napcat",
+    )
+
+    async def list_items(*_args: object, **kwargs: object) -> list[SimpleNamespace]:
+        assert kwargs["limit"] == expected_limit
+        return [default_node, specific_node]
+
+    monkeypatch.setattr(repository, "list_items", list_items)
+
+    node = await repository.get_command_node(
+        platform_id="qq",
+        adapter_id="~onebot.v11",
+        command_key="kick_member",
+        implementation_name="napcat",
+    )
+
+    assert node is specific_node
+
+
+@pytest.mark.asyncio
 async def test_visible_command_keys_filters_without_audit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Self, cast
 from unittest.mock import AsyncMock
 
 import pytest
 
+from src.plugins.nonebot_plugin_lingchu_bot.database.models import (
+    PermissionGrant,
+    PermissionGroupMember,
+    PermissionNode,
+)
+from src.plugins.nonebot_plugin_lingchu_bot.handle.qq.group import common
+from src.plugins.nonebot_plugin_lingchu_bot.repositories import (
+    permissions as repository,
+)
 from src.plugins.nonebot_plugin_lingchu_bot.services import permissions
 
 
@@ -47,6 +57,7 @@ async def test_default_permission_state_syncs_menu_tree(
         "upsert_native_role_mapping",
         AsyncMock(),
     )
+    monkeypatch.setattr(permissions, "_default_state_ensured", False)
 
     await permissions.ensure_default_permission_state()
 
@@ -54,6 +65,56 @@ async def test_default_permission_state_syncs_menu_tree(
     assert "lingchu/platform:qq/adapter:~onebot.v11" in nodes
     assert any(path.endswith("/command:kick_member") for path in nodes)
     assert any(grant["resource_type"] == "group" for grant in grants)
+
+
+@pytest.mark.asyncio
+async def test_default_permission_state_is_cached_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes: dict[str, SimpleNamespace] = {}
+    upsert_paths: list[str] = []
+
+    async def upsert_node(**fields: object) -> SimpleNamespace:
+        upsert_paths.append(str(fields["path"]))
+        node = SimpleNamespace(id=len(nodes) + 1, **fields)
+        nodes[str(fields["path"])] = node
+        return node
+
+    async def get_node_by_path(path: str) -> SimpleNamespace | None:
+        return nodes.get(path)
+
+    async def upsert_group(**fields: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=1 if fields["key"] == "native-owner" else 2,
+            **fields,
+        )
+
+    upsert_grant = AsyncMock()
+    upsert_capability_contract = AsyncMock()
+    upsert_native_role_mapping = AsyncMock()
+    monkeypatch.setattr(permissions.repository, "upsert_node", upsert_node)
+    monkeypatch.setattr(permissions.repository, "get_node_by_path", get_node_by_path)
+    monkeypatch.setattr(permissions.repository, "upsert_group", upsert_group)
+    monkeypatch.setattr(permissions.repository, "upsert_grant", upsert_grant)
+    monkeypatch.setattr(
+        permissions.repository,
+        "upsert_capability_contract",
+        upsert_capability_contract,
+    )
+    monkeypatch.setattr(
+        permissions.repository,
+        "upsert_native_role_mapping",
+        upsert_native_role_mapping,
+    )
+    monkeypatch.setattr(permissions, "_default_state_ensured", False)
+
+    await permissions.ensure_default_permission_state()
+    await permissions.ensure_default_permission_state()
+
+    assert upsert_grant.await_count > 0
+    upsert_capability_contract.assert_awaited()
+    upsert_native_role_mapping.assert_awaited()
+    assert upsert_paths.count("lingchu") == 1
 
 
 @pytest.mark.asyncio
@@ -174,3 +235,106 @@ async def test_check_permission_denies_disabled_capability(
 
     assert decision.allowed is False
     assert decision.result == permissions.CAPABILITY_DENY_RESULT
+
+
+@pytest.mark.asyncio
+async def test_permission_guard_fails_closed_when_context_missing() -> None:
+    async def handler() -> None:
+        msg = "handler should not run without permission context"
+        raise AssertionError(msg)
+
+    command = SimpleNamespace(
+        _lingchu_command_key="kick_member",
+        finish=AsyncMock(return_value=None),
+    )
+
+    wrapped = common._permission_guard(
+        cast("common.GroupCommand", command),
+        "~onebot.v11",
+        handler,
+    )
+
+    await wrapped()
+
+    command.finish.assert_awaited_once_with(message="系统错误：无法验证权限")
+
+
+@pytest.mark.asyncio
+async def test_find_matching_grant_uses_global_group_priority(  # noqa: C901
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    low_group = SimpleNamespace(id=1, priority=100)
+    high_group = SimpleNamespace(id=2, priority=900)
+    high_grant = SimpleNamespace(id=20)
+    high_node = SimpleNamespace(id=30, path="lingchu/platform:qq")
+    target_node = SimpleNamespace(
+        id=40,
+        adapter_id="~onebot.v11",
+        path="lingchu/platform:qq/adapter:~onebot.v11/command:kick_member",
+    )
+    member_query_count = 1
+    native_query_count = 2
+    grant_query_count = 3
+    statements: list[object] = []
+
+    class Result:
+        def __init__(self, rows: list[object]) -> None:
+            self._rows = rows
+
+        def all(self) -> list[object]:
+            return self._rows
+
+        def scalars(self) -> list[object]:
+            return self._rows
+
+    class FakeSession:
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def execute(self, statement: object) -> Result:
+            statements.append(statement)
+            if len(statements) == member_query_count:
+                return Result([(low_group, SimpleNamespace())])
+            if len(statements) == native_query_count:
+                return Result([high_group])
+            if len(statements) == grant_query_count:
+                return Result([(high_group, high_grant, high_node)])
+            msg = "find_matching_grant should issue one grant query"
+            raise AssertionError(msg)
+
+    def get_fake_session() -> FakeSession:
+        return FakeSession()
+
+    monkeypatch.setattr(repository, "get_session", get_fake_session)
+
+    group, grant, node = await repository.find_matching_grant(
+        platform_id="qq",
+        user_id="100",
+        target_node=cast("PermissionNode", target_node),
+        resource_type="group",
+        resource_id="200",
+        native_roles=frozenset({"owner"}),
+    )
+
+    assert group is high_group
+    assert grant is high_grant
+    assert node is high_node
+    assert len(statements) == grant_query_count
+
+
+def test_permission_models_have_cascade_foreign_keys() -> None:
+    member_group_fk = next(
+        iter(PermissionGroupMember.__table__.c.group_id.foreign_keys)
+    )
+    grant_group_fk = next(iter(PermissionGrant.__table__.c.group_id.foreign_keys))
+    grant_node_fk = next(iter(PermissionGrant.__table__.c.node_id.foreign_keys))
+
+    assert member_group_fk.target_fullname == "lingchu_permission_groups.id"
+    assert member_group_fk.ondelete == "CASCADE"
+    assert grant_group_fk.target_fullname == "lingchu_permission_groups.id"
+    assert grant_group_fk.ondelete == "CASCADE"
+    assert grant_node_fk.target_fullname == "lingchu_permission_nodes.id"
+    assert grant_node_fk.ondelete == "CASCADE"


### PR DESCRIPTION
## Summary
- 新增权限相关 ORM 模型，用于权限树、组映射、授权和审计
- 为 QQ 群命令绑定 `command_key`，并在处理链路中加入权限校验
- 菜单支持按当前会话可见命令过滤，避免展示无权限项
- 启动时初始化默认权限状态，确保基础权限结构可用

## Testing
- Not run (not requested)

## Summary by Sourcery

Introduce a persistent, tree-based permission system and enforce it for QQ group commands and menus.

New Features:
- Add ORM models and repository helpers for permission trees, groups, grants, native role mappings, capability contracts, and permission audit logs.
- Introduce a permission service to sync the menu-based permission tree, evaluate command permissions, and expose helper APIs for grants, group membership, and visibility queries.
- Add a QQ group "permission" management command for superusers to inspect and modify permission state at runtime.

Enhancements:
- Guard QQ group command handlers with permission checks derived from bound command keys and event context, failing closed on missing context.
- Filter menu pages and items based on the caller's allowed command set so users only see commands they can execute.
- Bind stable command keys to existing QQ group commands to integrate them into the permission system.
- Initialize default permission state during startup so the permission tree and native role mappings are ready before handling events.

Tests:
- Add unit tests covering default permission tree synchronization and caching, permission decision logic, repository grant selection, and permission model foreign key cascades.
- Extend command trigger tests to cover the new permission command trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 增强完整权限管理：新增权限树、权限组/成员、授权（包含原生角色映射）与能力契约，并记录权限/代理操作审计日志。
  * 新增“权限”命令：同步权限树、查看/导出权限树、进行授权与成员管理、切换原生身份映射。
  * 菜单与命令支持按事件权限进行可见性过滤，并提供权限键绑定能力。

* **Bug Fixes / Behavior**
  * 各命令入口增加统一权限校验；缺失权限上下文时安全失败并返回固定错误提示。

* **Tests**
  * 新增大量权限体系与菜单可见性过滤相关测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->