### PR TITLE
♻️ refactor(audit): 统一结构化审计载荷

### DIFF
--- a/.github/note/AGENTS-zh.md
+++ b/.github/note/AGENTS-zh.md
@@ -363,6 +363,12 @@ GitHub Actions runs on push to `main`/`dev` and on PRs:
 - **不适用场景**：调用者需要结果的操作，或函数返回前必须完成的操作。这些情况下直接使用 `await`。
 - **引用管理**：辅助函数将任务存储在模块级 set 中，防止 Python GC 过早取消；done-callback 在记录任何异常后移除引用。
 
+### 结构化请求对象
+
+- **仓储 API**：需要多项关联字段的写入/审计 API 优先使用冻结 dataclass 请求对象。例如 `repositories/blocklist.py` 中的 `BlocklistUpsert` 和 `repositories/message_store.py` 中的 `AuditEvent`。
+- **命令审计**：命令审计载荷使用 `handle/qq/adapters/onebot11/default/common.py` 中的 `CommandAudit`，再传给 `record_audit_fire_and_forget()` 或 `record_command_audit()`。
+- **不要新增长参数列表**：如果新 helper 需要 platform、adapter、bot、group、target、reason、duration 等多个耦合字段，定义请求对象，而不是继续扩展函数签名。
+
 ### 命令处理器状态控制（静默模式与处理门控）
 
 - **位置**：`src/plugins/nonebot_plugin_lingchu_bot/core/bot_state.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,12 @@ GitHub Actions runs on push to `main`/`dev` and on PRs:
 - **Do NOT use for**: operations whose results are needed by the caller, or operations that must complete before the function returns. In those cases, use `await` directly.
 - **Reference management**: the helper stores the task in a module-level set so Python's GC does not cancel it prematurely; the done-callback removes the reference after logging any exception.
 
+### Structured Request Objects
+
+- **Repository APIs**: Prefer frozen dataclass request objects for write/audit APIs that need many related fields. Examples include `BlocklistUpsert` in `repositories/blocklist.py` and `AuditEvent` in `repositories/message_store.py`.
+- **Command audit**: Use `CommandAudit` from `handle/qq/adapters/onebot11/default/common.py` for command audit payloads, then pass it to `record_audit_fire_and_forget()` or `record_command_audit()`.
+- **Do NOT add new long parameter lists**: If a new helper needs more than a few coupled fields such as platform, adapter, bot, group, target, reason, and duration, define a request object instead of expanding the function signature.
+
 ### Command Handler State Control (Silent Mode & Handle Gate)
 
 - **Location**: `src/plugins/nonebot_plugin_lingchu_bot/core/bot_state.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,12 @@ GitHub Actions runs on push to `main`/`dev` and on PRs:
 - **Do NOT use for**: operations whose results are needed by the caller, or operations that must complete before the function returns. In those cases, use `await` directly.
 - **Reference management**: the helper stores the task in a module-level set so Python's GC does not cancel it prematurely; the done-callback removes the reference after logging any exception.
 
+### Structured Request Objects
+
+- **Repository APIs**: Prefer frozen dataclass request objects for write/audit APIs that need many related fields. Examples include `BlocklistUpsert` in `repositories/blocklist.py` and `AuditEvent` in `repositories/message_store.py`.
+- **Command audit**: Use `CommandAudit` from `handle/qq/adapters/onebot11/default/common.py` for command audit payloads, then pass it to `record_audit_fire_and_forget()` or `record_command_audit()`.
+- **Do NOT add new long parameter lists**: If a new helper needs more than a few coupled fields such as platform, adapter, bot, group, target, reason, and duration, define a request object instead of expanding the function signature.
+
 ### Command Handler State Control (Silent Mode & Handle Gate)
 
 - **Location**: `src/plugins/nonebot_plugin_lingchu_bot/core/bot_state.py`

--- a/apps/docs/content/docs/platforms/qq/onebot-v11/default.mdx
+++ b/apps/docs/content/docs/platforms/qq/onebot-v11/default.mdx
@@ -70,7 +70,8 @@ Before executing a remote action, the bot checks:
 - `resolve_user_onebot11(user, bot, event)` — Resolves `At | int` to `(user_id, name)` tuple. Raises `ValueError` on invalid input.
 - `check_target_privilege(bot, event, target_user_id, cmd_matcher)` — Checks whether the target user is an admin/owner; rejects the operation unless the operator is the group owner or a superuser. Returns `True` when the check passes.
 - `check_bot_privilege(bot, group_id, cmd_matcher)` — Checks whether the bot has admin/owner role in the given group. Returns `True` when the check passes.
-- `record_command_audit(bot, event, *, action, target_user_id=None, reason=None, duration=None, group_id=None)` — Writes a command-level audit log entry via the message store repository.
+- `CommandAudit(action, target_user_id=None, reason=None, duration=None, group_id=None)` — Carries command audit payloads.
+- `record_command_audit(bot, event, CommandAudit(...))` / `record_audit_fire_and_forget(bot, event, CommandAudit(...))` — Writes a command-level audit log entry via the message store repository, either awaited directly or scheduled in the background.
 
 ## Permission API Integration
 

--- a/apps/docs/content/docs/platforms/qq/onebot-v11/default.zh.mdx
+++ b/apps/docs/content/docs/platforms/qq/onebot-v11/default.zh.mdx
@@ -70,7 +70,8 @@ title: 默认实现
 - `resolve_user_onebot11(user, bot, event)` — 把 `At | int` 解析为 `(user_id, name)` 元组。输入无效时抛出 `ValueError`。
 - `check_target_privilege(bot, event, target_user_id, cmd_matcher)` — 检查目标用户是否为管理员/群主；操作者不是群主或超级用户时拒绝操作。检查通过返回 `True`。
 - `check_bot_privilege(bot, group_id, cmd_matcher)` — 检查机器人在指定群内是否具有管理员/群主角色。检查通过返回 `True`。
-- `record_command_audit(bot, event, *, action, target_user_id=None, reason=None, duration=None, group_id=None)` — 通过消息存储仓库写入命令级审计日志。
+- `CommandAudit(action, target_user_id=None, reason=None, duration=None, group_id=None)` — 承载命令审计载荷。
+- `record_command_audit(bot, event, CommandAudit(...))` / `record_audit_fire_and_forget(bot, event, CommandAudit(...))` — 通过消息存储仓库写入命令级审计日志，可直接等待执行，也可作为后台任务调度。
 
 ## 权限 API 集成
 

--- a/src/plugins/nonebot_plugin_lingchu_bot/database/json5_store/_async_db.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/database/json5_store/_async_db.py
@@ -507,32 +507,20 @@ class RobustAsyncJSON5DB:
             raise DatabaseClosedError
         return await self._set_with_condition(key_path, value, mode="update")
 
+    async def _commit_data_copy(self, data_copy: dict[str, Any]) -> None:
+        """Commit a prepared data snapshot through the shared write semantics."""
+        if self.auto_save:
+            await self._unsafe_save_data(data_copy)
+        self._data = data_copy
+
     async def _set_with_condition(self, key_path: str, value: Any, mode: str) -> bool:
         """按模式写入单个路径。"""
         async with self._lock:
-            if self.auto_save:
-                data_copy = await _deepcopy_async(self._data)
-
-                segments = self._validate_path(key_path)
-                create_missing = mode != "update"
-                parent, key, exists = self._navigate_to_parent(
-                    segments, create_missing=create_missing, root=data_copy
-                )
-
-                if mode == "create" and exists:
-                    return False
-                if mode == "update" and (parent is None or not exists):
-                    return False
-
-                parent[key] = value
-
-                await self._unsafe_save_data(data_copy)
-                self._data = data_copy
-                return True
+            data_copy = await _deepcopy_async(self._data)
             segments = self._validate_path(key_path)
             create_missing = mode != "update"
             parent, key, exists = self._navigate_to_parent(
-                segments, create_missing=create_missing
+                segments, create_missing=create_missing, root=data_copy
             )
 
             if mode == "create" and exists:
@@ -541,6 +529,7 @@ class RobustAsyncJSON5DB:
                 return False
 
             parent[key] = value
+            await self._commit_data_copy(data_copy)
             return True
 
     async def set_batch(self, updates: dict[str, Any]) -> None:
@@ -565,9 +554,7 @@ class RobustAsyncJSON5DB:
                 )
                 parent[key] = val
 
-            if self.auto_save:
-                await self._unsafe_save_data(data_copy)
-            self._data = data_copy
+            await self._commit_data_copy(data_copy)
 
     async def delete(self, key_path: str) -> bool:
         """删除指定路径的值。
@@ -578,27 +565,15 @@ class RobustAsyncJSON5DB:
         if self._closed:
             raise DatabaseClosedError
         async with self._lock:
-            if self.auto_save:
-                data_copy = await _deepcopy_async(self._data)
-
-                segments = self._validate_path(key_path)
-                parent, key, exists = self._navigate_to_parent(
-                    segments, create_missing=False, root=data_copy
-                )
-                if not exists:
-                    return False
-
-                del parent[key]
-                await self._unsafe_save_data(data_copy)
-                self._data = data_copy
-                return True
+            data_copy = await _deepcopy_async(self._data)
             segments = self._validate_path(key_path)
             parent, key, exists = self._navigate_to_parent(
-                segments, create_missing=False
+                segments, create_missing=False, root=data_copy
             )
             if not exists:
                 return False
             del parent[key]
+            await self._commit_data_copy(data_copy)
             return True
 
     async def exists(self, key_path: str) -> bool:
@@ -617,12 +592,7 @@ class RobustAsyncJSON5DB:
         if self._closed:
             raise DatabaseClosedError
         async with self._lock:
-            if self.auto_save:
-                empty: dict[str, Any] = {}
-                await self._unsafe_save_data(empty)
-                self._data = empty
-            else:
-                self._data = {}
+            await self._commit_data_copy({})
 
     def _navigate_to_parent(
         self,

--- a/src/plugins/nonebot_plugin_lingchu_bot/database/orm_crud/_bulk.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/database/orm_crud/_bulk.py
@@ -28,6 +28,20 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.elements import ColumnElement
 
 
+async def _finalize_bulk_create[T: Model](
+    session: AsyncSession,
+    instances: Sequence[T],
+    *,
+    commit: bool,
+) -> None:
+    if commit:
+        await session.commit()
+        for obj in instances:
+            await session.refresh(obj)
+    else:
+        await session.flush()
+
+
 async def bulk_create[T: Model](
     model: type[T],
     objs: list[dict[str, Any]],
@@ -55,12 +69,7 @@ async def bulk_create[T: Model](
             instances = [model(**fields) for fields in validated_objs]
             s.add_all(instances)
             try:
-                if commit:
-                    await s.commit()
-                    for obj in instances:
-                        await s.refresh(obj)
-                else:
-                    await s.flush()
+                await _finalize_bulk_create(s, instances, commit=commit)
             except SQLAlchemyError as e:
                 await s.rollback()
                 raise DatabaseError("Bulk create failed") from e
@@ -84,12 +93,7 @@ async def bulk_create[T: Model](
                 )
                 failed.append((idx, msg))
         try:
-            if commit:
-                await s.commit()
-                for obj in created:
-                    await s.refresh(obj)
-            else:
-                await s.flush()
+            await _finalize_bulk_create(s, created, commit=commit)
         except SQLAlchemyError as e:
             await s.rollback()
             raise DatabaseError("Bulk create failed") from e

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/block.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/block.py
@@ -31,6 +31,7 @@ from ....commands.common import selected_adapter_handle
 from .common import (
     ONEBOT_V11_ADAPTER_ID,
     QQ_PLATFORM_ID,
+    CommandAudit,
     bot_id,
     check_bot_privilege,
     check_target_privilege,
@@ -112,10 +113,12 @@ async def _block_member(  # noqa: PLR0913
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="block_member",
-        target_user_id=target_user_id,
-        duration=duration,
-        reason=reason,
+        CommandAudit(
+            action="block_member",
+            target_user_id=target_user_id,
+            duration=duration,
+            reason=reason_text,
+        ),
     )
 
     scope_text = await _("全局") if scope == "global" else await _("本群")
@@ -209,7 +212,13 @@ async def _unblock_member(  # noqa: PLR0913
 
     # 记录审计
     await record_audit_fire_and_forget(
-        bot, event, action="unblock_member", target_user_id=target_user_id
+        bot,
+        event,
+        CommandAudit(
+            action="unblock_member",
+            target_user_id=target_user_id,
+            reason=reason_text,
+        ),
     )
 
     scope_text = await _("全局") if scope == "global" else await _("本群")
@@ -294,7 +303,9 @@ async def _clear_blocklist(
         return await _finish_database_error(command, await _("清空黑名单"), error)
 
     # 记录审计
-    await record_audit_fire_and_forget(bot, event, action="clear_blocklist")
+    await record_audit_fire_and_forget(
+        bot, event, CommandAudit(action="clear_blocklist", reason=reason_text)
+    )
 
     scope_text = await _("全局") if scope == "global" else await _("本群")
     message = (

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/common.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/common.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, Final
 
 from nonebot import logger
@@ -13,6 +14,7 @@ from nonebot_plugin_alconna.uniseg import At
 
 from ......i18n import _async as _
 from ......repositories.blocklist import (
+    BlocklistUpsert,
     BlockScope,
     expires_at_from_duration,
     upsert_block,
@@ -25,6 +27,17 @@ MUTE_DURATION_MIN: Final[int] = 1
 MUTE_DURATION_MAX: Final[int] = 30 * 24 * 60 * 60  # 30 天
 
 type GroupAction = Callable[[], Awaitable[Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandAudit:
+    """Command audit payload shared by local and remote handlers."""
+
+    action: str
+    target_user_id: int | None = None
+    reason: str | None = None
+    duration: int | None = None
+    group_id: int | None = None
 
 
 async def target_user_onebot11(
@@ -170,15 +183,17 @@ async def store_block_record(  # noqa: PLR0913
 ) -> None:
     """存储黑名单记录（本地和远程统一入口）"""
     await upsert_block(
-        platform_id=QQ_PLATFORM_ID,
-        adapter_id=ONEBOT_V11_ADAPTER_ID,
-        bot_id=bot_id(bot),
-        scope=scope,
-        group_id=group_id,
-        user_id=user_id,
-        operator_id=operator_id,
-        reason=reason,
-        expires_at=expires_at_from_duration(duration),
+        BlocklistUpsert(
+            platform_id=QQ_PLATFORM_ID,
+            adapter_id=ONEBOT_V11_ADAPTER_ID,
+            bot_id=bot_id(bot),
+            scope=scope,
+            group_id=group_id,
+            user_id=user_id,
+            operator_id=operator_id,
+            reason=reason,
+            expires_at=expires_at_from_duration(duration),
+        )
     )
 
 
@@ -250,44 +265,41 @@ async def check_bot_privilege(
     return True
 
 
-async def record_command_audit(  # noqa: PLR0913
+async def record_command_audit(
     bot: Onebot11Bot,
     event: Onebot11GroupMessageEvent,
-    *,
-    action: str,
-    target_user_id: int | None = None,
-    reason: str | None = None,
-    duration: int | None = None,
-    group_id: int | None = None,
+    audit: CommandAudit,
 ) -> None:
     """记录命令级审计日志。"""
     from ......database.orm_crud import DatabaseError
-    from ......repositories.message_store import record_api_call
+    from ......repositories.message_store import AuditEvent, record_api_call
 
-    audit_group_id = group_id if group_id is not None else event.group_id
+    audit_group_id = audit.group_id if audit.group_id is not None else event.group_id
     data_summary = (
-        f"operator={event.user_id}, target={target_user_id}, "
-        f"action={action}, group={audit_group_id}"
+        f"operator={event.user_id}, target={audit.target_user_id}, "
+        f"action={audit.action}, group={audit_group_id}"
     )
-    if duration is not None:
-        data_summary += f", duration={duration}"
-    if reason is not None:
-        data_summary += f", reason={reason}"
+    if audit.duration is not None:
+        data_summary += f", duration={audit.duration}"
+    if audit.reason is not None:
+        data_summary += f", reason={audit.reason}"
 
     try:
         await record_api_call(
-            platform_id=QQ_PLATFORM_ID,
-            adapter_id=ONEBOT_V11_ADAPTER_ID,
-            protocol_id=None,
-            bot_id=bot_id(bot),
-            api_name=f"command:{action}",
-            data_summary=data_summary,
-            result_summary="success",
-            exception_summary=None,
-            audit_type="command",
+            AuditEvent(
+                platform_id=QQ_PLATFORM_ID,
+                adapter_id=ONEBOT_V11_ADAPTER_ID,
+                protocol_id=None,
+                bot_id=bot_id(bot),
+                api_name=f"command:{audit.action}",
+                data_summary=data_summary,
+                result_summary="success",
+                exception_summary=None,
+                audit_type="command",
+            )
         )
     except DatabaseError:
-        logger.exception(f"记录命令审计失败: action={action}")
+        logger.exception(f"记录命令审计失败: action={audit.action}")
 
 
 def format_user_display_name(
@@ -312,14 +324,10 @@ def format_user_display_name(
     return f"{target_name}({target_user_id})" if target_name else str(target_user_id)
 
 
-async def record_audit_fire_and_forget(  # noqa: PLR0913
+async def record_audit_fire_and_forget(
     bot: Onebot11Bot,
     event: Onebot11GroupMessageEvent,
-    *,
-    action: str,
-    target_user_id: int | None = None,
-    reason: str | None = None,
-    duration: int | None = None,
+    audit: CommandAudit,
 ) -> None:
     """异步记录审计日志（fire-and-forget 模式）。
 
@@ -331,10 +339,7 @@ async def record_audit_fire_and_forget(  # noqa: PLR0913
         record_command_audit(
             bot,
             event,
-            action=action,
-            target_user_id=target_user_id,
-            reason=reason,
-            duration=duration,
+            audit,
         ),
-        name=f"audit:{action}",
+        name=f"audit:{audit.action}",
     )

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/kick.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/kick.py
@@ -16,6 +16,7 @@ from ....commands.kick import kick_member_cmd
 from .common import (
     ONEBOT_V11_ADAPTER_ID,
     QQ_PLATFORM_ID,
+    CommandAudit,
     bot_id,
     check_bot_privilege,
     check_self_target,
@@ -82,9 +83,11 @@ async def _kick_member(  # noqa: PLR0911
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="kick_member",
-        target_user_id=target_user_id,
-        reason=reason,
+        CommandAudit(
+            action="kick_member",
+            target_user_id=target_user_id,
+            reason=reason,
+        ),
     )
 
     # 反馈结果

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/member.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/member.py
@@ -17,6 +17,7 @@ from ....commands.member import (
     unset_group_member_admin_cmd,
 )
 from .common import (
+    CommandAudit,
     bot_self_id_safe,
     check_bot_privilege,
     check_target_privilege,
@@ -79,8 +80,7 @@ async def onebot11_set_group_member_card(
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="set_member_card",
-        target_user_id=target_user_id,
+        CommandAudit(action="set_member_card", target_user_id=target_user_id),
     )
 
     # 8. 格式化反馈消息
@@ -149,8 +149,7 @@ async def onebot11_set_group_member_special_title(
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="set_member_title",
-        target_user_id=target_user_id,
+        CommandAudit(action="set_member_title", target_user_id=target_user_id),
     )
 
     # 8. 格式化反馈消息
@@ -197,8 +196,7 @@ async def onebot11_set_group_member_admin(
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="set_member_admin",
-        target_user_id=target_user_id,
+        CommandAudit(action="set_member_admin", target_user_id=target_user_id),
     )
 
     # 6. 格式化反馈消息
@@ -262,8 +260,7 @@ async def onebot11_kick_group_member(
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="kick_member",
-        target_user_id=target_user_id,
+        CommandAudit(action="kick_member", target_user_id=target_user_id),
     )
 
     # 6. 格式化反馈消息

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/mute.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/mute.py
@@ -19,6 +19,7 @@ from ....commands.mute import (
 from .common import (
     MUTE_DURATION_MAX,
     MUTE_DURATION_MIN,
+    CommandAudit,
     bot_self_id_safe,
     check_bot_privilege,
     check_self_target,
@@ -78,10 +79,12 @@ async def onebot11_mute(  # noqa: PLR0911
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="member_mute",
-        target_user_id=target_user_id,
-        duration=duration,
-        reason=reason,
+        CommandAudit(
+            action="member_mute",
+            target_user_id=target_user_id,
+            duration=duration,
+            reason=reason,
+        ),
     )
 
     # 7. 格式化反馈消息
@@ -121,7 +124,7 @@ async def onebot11_whole_mute(
         return await whole_mute_cmd.finish(await _("全体禁言失败，操作被拒绝"))
 
     # 3. 记录审计
-    await record_audit_fire_and_forget(bot, event, action="whole_mute")
+    await record_audit_fire_and_forget(bot, event, CommandAudit(action="whole_mute"))
 
     return await whole_mute_cmd.finish(await _("全体禁言成功"))
 
@@ -160,8 +163,7 @@ async def onebot11_unmute(
     await record_audit_fire_and_forget(
         bot,
         event,
-        action="member_unmute",
-        target_user_id=target_user_id,
+        CommandAudit(action="member_unmute", target_user_id=target_user_id),
     )
 
     # 5. 格式化反馈消息
@@ -187,6 +189,6 @@ async def onebot11_whole_unmute(
         return await whole_unmute_cmd.finish(await _("全体解禁失败，操作被拒绝"))
 
     # 记录审计
-    await record_audit_fire_and_forget(bot, event, action="whole_unmute")
+    await record_audit_fire_and_forget(bot, event, CommandAudit(action="whole_unmute"))
 
     return await whole_unmute_cmd.finish(await _("全体解禁成功"))

--- a/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/remote.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/handle/qq/adapters/onebot11/default/remote.py
@@ -11,7 +11,6 @@ from nonebot.adapters.onebot.v11.exception import ActionFailed as OneBot11Action
 from nonebot_plugin_alconna.uniseg import At
 from nonebot_plugin_alconna.uniseg import Image as UniImage
 
-from ......core.async_utils import fire_and_forget
 from ......database.orm_crud import DatabaseError
 from ......i18n import _async as _
 from ......repositories.blocklist import (
@@ -36,12 +35,14 @@ from .common import (
     MUTE_DURATION_MIN,
     ONEBOT_V11_ADAPTER_ID,
     QQ_PLATFORM_ID,
+    CommandAudit,
     bot_id,
     check_bot_privilege,
     check_self_target,
     default_admin_reason,
     default_block_reason,
-    record_command_audit,
+    format_user_display_name,
+    record_audit_fire_and_forget,
     resolve_user_onebot11,
     store_block_record,
 )
@@ -226,22 +227,21 @@ async def onebot11_remote_mute(  # noqa: PLR0911, PLR0913
         return await remote_mute_cmd.finish(await _("远程禁言失败，操作被拒绝"))
 
     # 7. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot,
-            event,
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(
             action="remote_mute",
             target_user_id=target_user_id,
             duration=duration,
             reason=reason,
             group_id=group_id_int,
         ),
-        name="audit:remote_mute",
     )
 
     # 8. 格式化反馈消息
-    reason_text = await _("违反群规「默认」") if reason is None else reason
-    name_display = f"@{target_name}" if target_name else str(target_user_id)
+    reason_text = await default_block_reason(reason)
+    name_display = format_user_display_name(target_user_id, target_name)
     message = await _(
         "已远程禁言: \n"
         "目标群: {group_id}\n"
@@ -304,20 +304,20 @@ async def onebot11_remote_unmute(
         return await remote_unmute_cmd.finish(await _("远程解禁失败，操作被拒绝"))
 
     # 6. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot,
-            event,
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(
             action="remote_unmute",
             target_user_id=target_user_id,
+            reason=reason,
             group_id=group_id_int,
         ),
-        name="audit:remote_unmute",
     )
 
     # 7. 格式化反馈消息
-    reason_text = await _("管理员操作「默认」") if reason is None else reason
-    name_display = f"@{target_name}" if target_name else str(target_user_id)
+    reason_text = await default_admin_reason(reason)
+    name_display = format_user_display_name(target_user_id, target_name)
     message = await _(
         "已远程解禁: \n"
         "目标群: {group_id}\n"
@@ -366,11 +366,10 @@ async def onebot11_remote_whole_mute(
         )
 
     # 4. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot, event, action="remote_whole_mute", group_id=group_id_int
-        ),
-        name="audit:remote_whole_mute",
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(action="remote_whole_mute", group_id=group_id_int),
     )
 
     return await remote_whole_mute_cmd.finish(
@@ -409,11 +408,10 @@ async def onebot11_remote_whole_unmute(
         )
 
     # 4. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot, event, action="remote_whole_unmute", group_id=group_id_int
-        ),
-        name="audit:remote_whole_unmute",
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(action="remote_whole_unmute", group_id=group_id_int),
     )
 
     return await remote_whole_unmute_cmd.finish(
@@ -466,7 +464,7 @@ async def onebot11_remote_kick(  # noqa: PLR0911
         return await remote_kick_cmd.finish(await _("查询黑名单失败，数据库异常"))
 
     if entry is None:
-        display_name = target_name or str(target_user_id)
+        display_name = format_user_display_name(target_user_id, target_name)
         message = await _("用户 {name} 不在黑名单中，无法执行踢出操作")
         return await remote_kick_cmd.finish(message.format(name=display_name))
 
@@ -482,20 +480,19 @@ async def onebot11_remote_kick(  # noqa: PLR0911
         return await remote_kick_cmd.finish(await _("远程踢出群成员失败，操作被拒绝"))
 
     # 7. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot,
-            event,
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(
             action="remote_kick",
             target_user_id=target_user_id,
             reason=reason,
             group_id=group_id_int,
         ),
-        name="audit:remote_kick",
     )
 
     # 8. 反馈结果
-    display_name = target_name or str(target_user_id)
+    display_name = format_user_display_name(target_user_id, target_name)
     reason_text = f"，原因: {reason}" if reason else ""
     message = await _("已远程踢出群成员 {name}{reason}，目标群: {group_id}")
     return await remote_kick_cmd.finish(
@@ -552,22 +549,21 @@ async def onebot11_remote_block(  # noqa: PLR0913
         return await remote_block_cmd.finish(await _("远程拉黑失败，操作被拒绝"))
 
     # 5. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot,
-            event,
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(
             action="remote_block",
             target_user_id=target_user_id,
             duration=duration,
             reason=reason,
             group_id=group_id_int,
         ),
-        name="audit:remote_block",
     )
 
     # 6. 格式化反馈消息
     duration_text = await _("永久") if duration is None else f"{duration} 秒"
-    name_display = f"@{target_name}" if target_name else str(target_user_id)
+    name_display = format_user_display_name(target_user_id, target_name)
     message = (
         await _(
             "已远程拉黑并踢出: \n"
@@ -631,19 +627,19 @@ async def onebot11_remote_unblock(
         return await remote_unblock_cmd.finish(await _("远程删黑失败，数据库异常"))
 
     # 5. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot,
-            event,
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(
             action="remote_unblock",
             target_user_id=target_user_id,
+            reason=reason,
             group_id=group_id_int,
         ),
-        name="audit:remote_unblock",
     )
 
     # 6. 格式化反馈消息
-    name_display = f"@{target_name}" if target_name else str(target_user_id)
+    name_display = format_user_display_name(target_user_id, target_name)
     message = (
         await _(
             "已远程删黑: \n"
@@ -713,11 +709,10 @@ async def onebot11_remote_announcement(
         return await remote_announcement_cmd.finish(await _("远程公告失败，操作被拒绝"))
 
     # 7. 记录审计
-    fire_and_forget(
-        record_command_audit(
-            bot, event, action="remote_announcement", group_id=group_id_int
-        ),
-        name="audit:remote_announcement",
+    await record_audit_fire_and_forget(
+        bot,
+        event,
+        CommandAudit(action="remote_announcement", group_id=group_id_int),
     )
 
     # 8. 反馈结果

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/blocklist.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/blocklist.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 
@@ -13,6 +14,20 @@ from ..database.orm_crud import delete, get_one, upsert
 BlockScope = Literal["group", "global"]
 
 GLOBAL_SCOPE_KEY = "*"
+
+
+@dataclass(frozen=True, slots=True)
+class BlocklistUpsert:
+    platform_id: str
+    adapter_id: str
+    bot_id: str
+    scope: BlockScope
+    group_id: str | int | None
+    user_id: str | int
+    operator_id: str | int | None
+    reason: str | None
+    expires_at: datetime | None
+    protocol_id: str | None = None
 
 
 def scope_key_for(scope: BlockScope, group_id: str | int | None = None) -> str:
@@ -32,33 +47,23 @@ def expires_at_from_duration(duration: int | None) -> datetime | None:
     return datetime.now(UTC) + timedelta(seconds=duration)
 
 
-async def upsert_block(  # noqa: PLR0913
-    *,
-    platform_id: str,
-    adapter_id: str,
-    protocol_id: str | None = None,
-    bot_id: str,
-    scope: BlockScope,
-    group_id: str | int | None,
-    user_id: str | int,
-    operator_id: str | int | None,
-    reason: str | None,
-    expires_at: datetime | None,
-) -> BlocklistEntry:
+async def upsert_block(request: BlocklistUpsert) -> BlocklistEntry:
     now = datetime.now(UTC)
-    scope_key = scope_key_for(scope, group_id)
+    scope_key = scope_key_for(request.scope, request.group_id)
     values = {
-        "platform_id": platform_id,
-        "adapter_id": adapter_id,
-        "protocol_id": protocol_id,
-        "bot_id": bot_id,
-        "scope": scope,
+        "platform_id": request.platform_id,
+        "adapter_id": request.adapter_id,
+        "protocol_id": request.protocol_id,
+        "bot_id": request.bot_id,
+        "scope": request.scope,
         "scope_key": scope_key,
-        "group_id": None if scope == "global" else str(group_id),
-        "user_id": str(user_id),
-        "operator_id": None if operator_id is None else str(operator_id),
-        "reason": reason,
-        "expires_at": expires_at,
+        "group_id": None if request.scope == "global" else str(request.group_id),
+        "user_id": str(request.user_id),
+        "operator_id": None
+        if request.operator_id is None
+        else str(request.operator_id),
+        "reason": request.reason,
+        "expires_at": request.expires_at,
         "created_at": now,
         "updated_at": now,
     }
@@ -75,10 +80,10 @@ async def upsert_block(  # noqa: PLR0913
             "user_id",
         ],
         update_values={
-            "protocol_id": protocol_id,
+            "protocol_id": request.protocol_id,
             "operator_id": values["operator_id"],
-            "reason": reason,
-            "expires_at": expires_at,
+            "reason": request.reason,
+            "expires_at": request.expires_at,
             "updated_at": now,
         },
     )

--- a/src/plugins/nonebot_plugin_lingchu_bot/repositories/message_store.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/repositories/message_store.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from ..database.models import AuditRecord, MessageRecord
 from ..database.orm_crud import create, delete, get_one, list_items, update, upsert
+
+
+@dataclass(frozen=True, slots=True)
+class AuditEvent:
+    platform_id: str
+    adapter_id: str
+    bot_id: str
+    api_name: str
+    data_summary: str | None
+    result_summary: str | None
+    exception_summary: str | None
+    protocol_id: str | None = None
+    audit_type: str = "api_call"
 
 
 async def record_event_received(  # noqa: PLR0913
@@ -98,30 +112,19 @@ async def record_matcher_result(  # noqa: PLR0913
     return True
 
 
-async def record_api_call(  # noqa: PLR0913
-    *,
-    platform_id: str,
-    adapter_id: str,
-    protocol_id: str | None = None,
-    bot_id: str,
-    api_name: str,
-    data_summary: str | None,
-    result_summary: str | None,
-    exception_summary: str | None,
-    audit_type: str = "api_call",
-) -> AuditRecord:
+async def record_api_call(event: AuditEvent) -> AuditRecord:
     """Record a platform API or lifecycle event as an audit record."""
     return await create(
         AuditRecord,
-        platform_id=platform_id,
-        adapter_id=adapter_id,
-        protocol_id=protocol_id,
-        bot_id=bot_id,
-        audit_type=audit_type,
-        event_type=api_name,
-        data_summary=data_summary,
-        result_summary=result_summary,
-        exception_summary=exception_summary,
+        platform_id=event.platform_id,
+        adapter_id=event.adapter_id,
+        protocol_id=event.protocol_id,
+        bot_id=event.bot_id,
+        audit_type=event.audit_type,
+        event_type=event.api_name,
+        data_summary=event.data_summary,
+        result_summary=event.result_summary,
+        exception_summary=event.exception_summary,
         created_at=datetime.now(UTC),
     )
 

--- a/src/plugins/nonebot_plugin_lingchu_bot/services/message_store.py
+++ b/src/plugins/nonebot_plugin_lingchu_bot/services/message_store.py
@@ -320,15 +320,18 @@ async def record_bot_lifecycle(bot: Bot, event_type: str) -> bool:
     platform_id, adapter_id = adapter_identity
     try:
         await repository.record_api_call(
-            platform_id=platform_id,
-            adapter_id=adapter_id,
-            protocol_id=None,
-            bot_id=_stringify(getattr(bot, "self_id", None), limit=128) or "unknown",
-            api_name=event_type,
-            data_summary=None,
-            result_summary=None,
-            exception_summary=None,
-            audit_type="lifecycle",
+            repository.AuditEvent(
+                platform_id=platform_id,
+                adapter_id=adapter_id,
+                protocol_id=None,
+                bot_id=_stringify(getattr(bot, "self_id", None), limit=128)
+                or "unknown",
+                api_name=event_type,
+                data_summary=None,
+                result_summary=None,
+                exception_summary=None,
+                audit_type="lifecycle",
+            )
         )
     except DatabaseError:
         logger.exception("Failed to record bot lifecycle event: %s", event_type)
@@ -450,14 +453,16 @@ async def message_store_on_called_api(
     async def _record() -> None:
         try:
             await repository.record_api_call(
-                platform_id=platform_id,
-                adapter_id=adapter_id,
-                protocol_id=None,
-                bot_id=bot_id,
-                api_name=api,
-                data_summary=_stringify(data),
-                result_summary=_stringify(result),
-                exception_summary=_stringify(exception),
+                repository.AuditEvent(
+                    platform_id=platform_id,
+                    adapter_id=adapter_id,
+                    protocol_id=None,
+                    bot_id=bot_id,
+                    api_name=api,
+                    data_summary=_stringify(data),
+                    result_summary=_stringify(result),
+                    exception_summary=_stringify(exception),
+                )
             )
         except DatabaseError:
             logger.exception("Failed to record platform API call: %s", api)

--- a/tests/handle/commands/test_common_helpers.py
+++ b/tests/handle/commands/test_common_helpers.py
@@ -8,6 +8,7 @@ from nonebot.adapters.onebot.v11.exception import ActionFailed as Onebot11Action
 
 from src.plugins.nonebot_plugin_lingchu_bot.database.orm_crud import DatabaseError
 from src.plugins.nonebot_plugin_lingchu_bot.handle.qq.adapters.onebot11.default.common import (  # noqa: E501
+    CommandAudit,
     check_bot_privilege,
     check_target_privilege,
     format_user_display_name,
@@ -188,19 +189,21 @@ class TestRecordCommandAudit:
             await record_command_audit(
                 mock_onebot11_bot,
                 mock_onebot11_event,
-                action="member_mute",
-                target_user_id=_TARGET_USER_ID,
-                duration=300,
-                reason="违规",
+                CommandAudit(
+                    action="member_mute",
+                    target_user_id=_TARGET_USER_ID,
+                    duration=300,
+                    reason="违规",
+                ),
             )
 
         mock_record.assert_called_once()
-        call_kwargs = mock_record.call_args.kwargs
-        assert call_kwargs["api_name"] == "command:member_mute"
-        assert call_kwargs["audit_type"] == "command"
-        assert "target=999" in call_kwargs["data_summary"]
-        assert "duration=300" in call_kwargs["data_summary"]
-        assert "reason=违规" in call_kwargs["data_summary"]
+        audit_event = mock_record.call_args.args[0]
+        assert audit_event.api_name == "command:member_mute"
+        assert audit_event.audit_type == "command"
+        assert "target=999" in audit_event.data_summary
+        assert "duration=300" in audit_event.data_summary
+        assert "reason=违规" in audit_event.data_summary
 
     @pytest.mark.asyncio
     async def test_database_error_silent(
@@ -214,8 +217,7 @@ class TestRecordCommandAudit:
             await record_command_audit(
                 mock_onebot11_bot,
                 mock_onebot11_event,
-                action="member_unmute",
-                target_user_id=_TARGET_USER_ID,
+                CommandAudit(action="member_unmute", target_user_id=_TARGET_USER_ID),
             )
 
 
@@ -270,10 +272,12 @@ class TestRecordAuditFireAndForget:
             await record_audit_fire_and_forget(
                 mock_onebot11_bot,
                 mock_onebot11_event,
-                action="member_mute",
-                target_user_id=_TARGET_USER_ID,
-                duration=300,
-                reason="违规",
+                CommandAudit(
+                    action="member_mute",
+                    target_user_id=_TARGET_USER_ID,
+                    duration=300,
+                    reason="违规",
+                ),
             )
 
         assert len(captured) == 1
@@ -299,10 +303,49 @@ class TestRecordAuditFireAndForget:
             await record_audit_fire_and_forget(
                 mock_onebot11_bot,
                 mock_onebot11_event,
-                action="whole_mute",
+                CommandAudit(action="whole_mute"),
             )
 
         assert len(captured) == 1
         coro, name = captured[0]
         assert name == "audit:whole_mute"
         coro.close()
+
+    @pytest.mark.asyncio
+    async def test_schedules_structured_remote_audit_with_group_id(
+        self, mock_onebot11_bot: MagicMock, mock_onebot11_event: MagicMock
+    ) -> None:
+        """远程命令通过结构化审计对象携带目标群。"""
+        captured: list[tuple[Any, str]] = []
+
+        def _spy(coro: Any, *, name: str = "fire_and_forget") -> Any:
+            captured.append((coro, name))
+            return MagicMock()
+
+        with (
+            patch(
+                "src.plugins.nonebot_plugin_lingchu_bot.core.async_utils.fire_and_forget",
+                side_effect=_spy,
+            ),
+            patch(
+                "src.plugins.nonebot_plugin_lingchu_bot.repositories.message_store.record_api_call",
+                AsyncMock(),
+            ) as mock_record,
+        ):
+            await record_audit_fire_and_forget(
+                mock_onebot11_bot,
+                mock_onebot11_event,
+                CommandAudit(
+                    action="remote_mute",
+                    target_user_id=_TARGET_USER_ID,
+                    duration=300,
+                    reason="违规",
+                    group_id=987654321,
+                ),
+            )
+            coro, name = captured[0]
+            assert name == "audit:remote_mute"
+            await coro
+
+        audit_event = mock_record.call_args.args[0]
+        assert "group=987654321" in audit_event.data_summary

--- a/tests/handle/commands/test_remote.py
+++ b/tests/handle/commands/test_remote.py
@@ -2,7 +2,6 @@
 
 import hashlib
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -49,18 +48,10 @@ onebot11_remote_whole_unmute = remote_module.onebot11_remote_whole_unmute
 
 
 @pytest.fixture(autouse=True)
-def _mock_fire_and_forget():
+def _mock_record_audit_fire_and_forget():
     """避免审计记录触发后台任务和数据库调用。"""
-    captured: list[tuple[Any, str]] = []
-
-    def _spy(coro: Any, *, name: str = "fire_and_forget") -> Any:
-        captured.append((coro, name))
-        return MagicMock()
-
-    with patch.object(remote_module, "fire_and_forget", side_effect=_spy):
+    with patch.object(remote_module, "record_audit_fire_and_forget", new=AsyncMock()):
         yield
-    for coro, _name in captured:
-        coro.close()
 
 
 @pytest.fixture

--- a/tests/repositories/test_blocklist.py
+++ b/tests/repositories/test_blocklist.py
@@ -33,20 +33,46 @@ def test_expires_at_from_duration_defaults_to_permanent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_upsert_block_accepts_structured_request() -> None:
+    upsert_mock = AsyncMock(return_value=_entry())
+
+    with patch.object(blocklist, "upsert", upsert_mock):
+        await blocklist.upsert_block(
+            blocklist.BlocklistUpsert(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                bot_id="bot-1",
+                scope="group",
+                group_id=123,
+                user_id=456,
+                operator_id=789,
+                reason="bad",
+                expires_at=None,
+            )
+        )
+
+    _, insert_values = upsert_mock.call_args.args[:2]
+    assert insert_values["scope_key"] == "123"
+    assert insert_values["user_id"] == "456"
+
+
+@pytest.mark.asyncio
 async def test_upsert_block_uses_scope_identity_and_update_values() -> None:
     upsert_mock = AsyncMock(return_value=_entry())
 
     with patch.object(blocklist, "upsert", upsert_mock):
         await blocklist.upsert_block(
-            platform_id="qq",
-            adapter_id="~onebot.v11",
-            bot_id="bot-1",
-            scope="group",
-            group_id=123,
-            user_id=456,
-            operator_id=789,
-            reason="bad",
-            expires_at=None,
+            blocklist.BlocklistUpsert(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                bot_id="bot-1",
+                scope="group",
+                group_id=123,
+                user_id=456,
+                operator_id=789,
+                reason="bad",
+                expires_at=None,
+            )
         )
 
     _, insert_values = upsert_mock.call_args.args[:2]
@@ -72,16 +98,18 @@ async def test_upsert_block_passes_protocol_id_through_to_upsert() -> None:
 
     with patch.object(blocklist, "upsert", upsert_mock):
         await blocklist.upsert_block(
-            platform_id="qq",
-            adapter_id="~onebot.v11",
-            protocol_id="napcat",
-            bot_id="bot-1",
-            scope="group",
-            group_id=123,
-            user_id=456,
-            operator_id=789,
-            reason="bad",
-            expires_at=None,
+            blocklist.BlocklistUpsert(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                protocol_id="napcat",
+                bot_id="bot-1",
+                scope="group",
+                group_id=123,
+                user_id=456,
+                operator_id=789,
+                reason="bad",
+                expires_at=None,
+            )
         )
 
     _, insert_values = upsert_mock.call_args.args[:2]
@@ -96,20 +124,46 @@ async def test_upsert_block_defaults_protocol_id_to_none() -> None:
 
     with patch.object(blocklist, "upsert", upsert_mock):
         await blocklist.upsert_block(
-            platform_id="qq",
-            adapter_id="~onebot.v11",
-            bot_id="bot-1",
-            scope="group",
-            group_id=123,
-            user_id=456,
-            operator_id=789,
-            reason="bad",
-            expires_at=None,
+            blocklist.BlocklistUpsert(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                bot_id="bot-1",
+                scope="group",
+                group_id=123,
+                user_id=456,
+                operator_id=789,
+                reason="bad",
+                expires_at=None,
+            )
         )
 
     _, insert_values = upsert_mock.call_args.args[:2]
     assert insert_values["protocol_id"] is None
     assert upsert_mock.call_args.kwargs["update_values"]["protocol_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_block_preserves_none_operator_id() -> None:
+    upsert_mock = AsyncMock(return_value=_entry())
+
+    with patch.object(blocklist, "upsert", upsert_mock):
+        await blocklist.upsert_block(
+            blocklist.BlocklistUpsert(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                bot_id="bot-1",
+                scope="group",
+                group_id=123,
+                user_id=456,
+                operator_id=None,
+                reason="bad",
+                expires_at=None,
+            )
+        )
+
+    _, insert_values = upsert_mock.call_args.args[:2]
+    assert insert_values["operator_id"] is None
+    assert upsert_mock.call_args.kwargs["update_values"]["operator_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/repositories/test_message_store.py
+++ b/tests/repositories/test_message_store.py
@@ -284,20 +284,46 @@ async def test_record_matcher_result_returns_false_when_not_found() -> None:
 
 
 @pytest.mark.asyncio
+async def test_record_api_call_accepts_structured_request() -> None:
+    audit_mock = _audit_record()
+    create_mock = AsyncMock(return_value=audit_mock)
+
+    with patch.object(message_store, "create", create_mock):
+        result = await message_store.record_api_call(
+            message_store.AuditEvent(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                protocol_id=None,
+                bot_id="bot-1",
+                api_name="send_message",
+                data_summary='{"message":"hello"}',
+                result_summary='{"message_id":"out-1"}',
+                exception_summary=None,
+            )
+        )
+
+    assert result is audit_mock
+    assert create_mock.call_args.kwargs["event_type"] == "send_message"
+    assert create_mock.call_args.kwargs["audit_type"] == "api_call"
+
+
+@pytest.mark.asyncio
 async def test_record_api_call_calls_create_with_audit_record() -> None:
     audit_mock = _audit_record()
     create_mock = AsyncMock(return_value=audit_mock)
 
     with patch.object(message_store, "create", create_mock):
         result = await message_store.record_api_call(
-            platform_id="qq",
-            adapter_id="~onebot.v11",
-            protocol_id=None,
-            bot_id="bot-1",
-            api_name="send_message",
-            data_summary='{"message":"hello"}',
-            result_summary='{"message_id":"out-1"}',
-            exception_summary=None,
+            message_store.AuditEvent(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                protocol_id=None,
+                bot_id="bot-1",
+                api_name="send_message",
+                data_summary='{"message":"hello"}',
+                result_summary='{"message_id":"out-1"}',
+                exception_summary=None,
+            )
         )
 
     assert result is audit_mock
@@ -323,14 +349,16 @@ async def test_record_api_call_passes_protocol_id_through_to_create() -> None:
 
     with patch.object(message_store, "create", create_mock):
         await message_store.record_api_call(
-            platform_id="qq",
-            adapter_id="~onebot.v11",
-            protocol_id="napcat",
-            bot_id="bot-1",
-            api_name="send_message",
-            data_summary='{"message":"hello"}',
-            result_summary='{"message_id":"out-1"}',
-            exception_summary=None,
+            message_store.AuditEvent(
+                platform_id="qq",
+                adapter_id="~onebot.v11",
+                protocol_id="napcat",
+                bot_id="bot-1",
+                api_name="send_message",
+                data_summary='{"message":"hello"}',
+                result_summary='{"message_id":"out-1"}',
+                exception_summary=None,
+            )
         )
 
     create_mock.assert_awaited_once()

--- a/tests/services/test_message_store.py
+++ b/tests/services/test_message_store.py
@@ -257,8 +257,11 @@ async def test_on_called_api_records_result(
     record_api.assert_awaited_once()
     record_api_args = record_api.await_args
     assert record_api_args is not None
-    assert record_api_args.kwargs["api_name"] == "send_message"
-    assert record_api_args.kwargs["adapter_id"] == "~onebot.v11"
+    audit_event = record_api_args.args[0]
+    assert audit_event.api_name == "send_message"
+    assert audit_event.adapter_id == "~onebot.v11"
+    assert audit_event.data_summary == "{'message': 'hello'}"
+    assert audit_event.result_summary == "{'message_id': 'out-1'}"
 
 
 async def test_lifecycle_and_api_recording_skip_disabled_known_adapter(


### PR DESCRIPTION
## Summary
- 将命令审计、blocklist 写入和 API 审计改为结构化请求对象，减少长参数列表
- 统一 OneBot v11 本地与远程命令的审计调用，并复用目标群和名称展示 helper
- 让 JSON5 数据库写路径与 ORM 批量创建复用共享提交/收尾入口
- 根据 AI PR review 补充 JSON5 写路径一致性和结构化 payload 边界测试

## Testing
- `uv run -m pytest tests/handle/commands tests/database tests/repositories tests/services -q`
- `uv run -m ruff check . --output-format=github`
- `uv run -m ruff format --check .`
- `uv run -m pyright .`
- `uv run -m ty check --output-format github`
- `git diff --check`
- `mcp__gitnexus.detect_changes({repo:"lingchu-bot",scope:"all"})`

## Review Follow-up
- Addressed Sourcery/AI review suggestions for `_commit_data_copy` reuse and additional structured request assertions.
- Amended the commit with repo-compliant gitmoji Conventional Commit subject and `Signed-off-by` trailer for DCO.